### PR TITLE
fix(windows): harden WorkBuddyAI 5.3.x support for 1.0.6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.cmd -text whitespace=cr-at-eol
+*.sh text eol=lf

--- a/.github/scripts/verify-api-contract.ps1
+++ b/.github/scripts/verify-api-contract.ps1
@@ -1,0 +1,80 @@
+param(
+  [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [string]$ExpectedVersion = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ('workdaddy-api-' + [guid]::NewGuid().ToString('N'))
+$dataDir = Join-Path $testRoot 'data'
+$workBuddyHome = Join-Path $testRoot '.workbuddy-ai'
+$daemon = $null
+
+try {
+  New-Item -ItemType Directory -Force -Path $dataDir, $workBuddyHome | Out-Null
+
+  $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+  $listener.Start()
+  $port = ([Net.IPEndPoint]$listener.LocalEndpoint).Port
+  $listener.Stop()
+
+  $env:WBSWITCH_DATA_DIR = $dataDir
+  $env:WBSWITCH_AUTH_FILE = Join-Path $testRoot 'missing-auth.info'
+  $env:WBSWITCH_WORKBUDDY_HOME = $workBuddyHome
+  $env:WBSWITCH_PORT = [string]$port
+  $env:WBSWITCH_CDP_PORT = '49199'
+
+  $daemonScript = (Resolve-Path (Join-Path $RepoRoot 'scripts\daemon.js')).Path
+  if (-not $ExpectedVersion) {
+    $versionMatch = [regex]::Match((Get-Content -LiteralPath $daemonScript -Raw), "DAEMON_VERSION\s*=\s*'([^']+)'" )
+    if (-not $versionMatch.Success) { throw 'could not resolve daemon version' }
+    $ExpectedVersion = $versionMatch.Groups[1].Value
+  }
+  $stdout = Join-Path $testRoot 'daemon.out.log'
+  $stderr = Join-Path $testRoot 'daemon.err.log'
+  $node = (Get-Command node -ErrorAction Stop).Source
+  $daemon = Start-Process -FilePath $node -ArgumentList @('--experimental-sqlite', ('"' + $daemonScript + '"')) `
+    -PassThru -WindowStyle Hidden -RedirectStandardOutput $stdout -RedirectStandardError $stderr
+
+  $health = $null
+  for ($attempt = 0; $attempt -lt 40 -and -not $health; $attempt++) {
+    Start-Sleep -Milliseconds 250
+    try { $health = Invoke-RestMethod "http://127.0.0.1:$port/healthz" -TimeoutSec 1 } catch {}
+  }
+  if (-not $health -or -not $health.ok -or $health.service -ne 'workdaddy' -or $health.version -ne $ExpectedVersion) {
+    throw 'healthz contract failed'
+  }
+
+  $unauth = Invoke-WebRequest "http://127.0.0.1:$port/api/status" -SkipHttpErrorCheck
+  if ([int]$unauth.StatusCode -ne 403) { throw "unauthenticated request returned $($unauth.StatusCode), expected 403" }
+
+  $wrong = Invoke-WebRequest "http://127.0.0.1:$port/api/status" -Headers @{ 'X-WorkDaddy-Token' = 'wrong' } -SkipHttpErrorCheck
+  if ([int]$wrong.StatusCode -ne 403) { throw "wrong token returned $($wrong.StatusCode), expected 403" }
+
+  $token = (Get-Content -LiteralPath (Join-Path $dataDir 'api-token') -Raw).Trim()
+  if ($token -notmatch '^[a-f0-9]{64}$') { throw 'invalid API token file' }
+  $headers = @{ 'X-WorkDaddy-Token' = $token }
+  $status = Invoke-RestMethod "http://127.0.0.1:$port/api/status" -Headers $headers
+  if (-not $status.ok -or $status.version -ne $ExpectedVersion) { throw 'authenticated status contract failed' }
+
+  $badJson = Invoke-WebRequest "http://127.0.0.1:$port/api/ask-mode-set" -Method Post -Headers $headers `
+    -ContentType 'application/json' -Body '{' -SkipHttpErrorCheck
+  if ([int]$badJson.StatusCode -ne 400) { throw "invalid JSON returned $($badJson.StatusCode), expected 400" }
+
+  $oversized = 'x' * (16MB + 1)
+  $tooLarge = Invoke-WebRequest "http://127.0.0.1:$port/api/ask-mode-set" -Method Post -Headers $headers `
+    -ContentType 'application/json' -Body $oversized -SkipHttpErrorCheck
+  if ([int]$tooLarge.StatusCode -ne 413) { throw "oversized body returned $($tooLarge.StatusCode), expected 413" }
+
+  Write-Output "API contract passed: health=200 unauth=403 wrong-token=403 auth=200 invalid-json=400 oversized=413"
+} finally {
+  if ($daemon -and -not $daemon.HasExited) {
+    Stop-Process -Id $daemon.Id -Force
+    $daemon.WaitForExit(5000) | Out-Null
+  }
+  $tempBase = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+  $resolvedRoot = [IO.Path]::GetFullPath($testRoot)
+  if ($resolvedRoot.StartsWith($tempBase, [StringComparison]::OrdinalIgnoreCase) -and
+      (Split-Path $resolvedRoot -Leaf).StartsWith('workdaddy-api-')) {
+    Remove-Item -LiteralPath $resolvedRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/.github/scripts/verify-update-guard.ps1
+++ b/.github/scripts/verify-update-guard.ps1
@@ -1,0 +1,40 @@
+param(
+  [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+$guardRoot = Join-Path ([IO.Path]::GetTempPath()) ('workdaddy-update-guard-' + [guid]::NewGuid().ToString('N'))
+$appDir = Join-Path $guardRoot 'installed'
+$packageDir = Join-Path $guardRoot 'bad-package'
+$fakeAppData = Join-Path $guardRoot 'appdata'
+$previousAppData = $env:APPDATA
+
+try {
+  New-Item -ItemType Directory -Force -Path $appDir, $packageDir, $fakeAppData | Out-Null
+  Set-Content -LiteralPath (Join-Path $appDir 'preserve.marker') -Value 'keep'
+  Set-Content -LiteralPath (Join-Path $packageDir 'not-workdaddy.txt') -Value 'invalid'
+  $badZip = Join-Path $guardRoot 'invalid.zip'
+  Compress-Archive -Path (Join-Path $packageDir '*') -DestinationPath $badZip
+
+  $env:APPDATA = $fakeAppData
+  $applyScript = (Resolve-Path (Join-Path $RepoRoot 'scripts\apply-update.ps1')).Path
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $applyScript -SrcZip $badZip -AppDir $appDir -Port 49999
+  if ($LASTEXITCODE -ne 1) { throw "invalid update returned $LASTEXITCODE, expected 1" }
+  if (-not (Test-Path -LiteralPath (Join-Path $appDir 'preserve.marker') -PathType Leaf)) {
+    throw 'existing installation changed before package validation completed'
+  }
+
+  Write-Output 'Update guard passed: invalid package rejected and existing installation preserved'
+} finally {
+  $env:APPDATA = $previousAppData
+  $tempBase = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+  $resolvedRoot = [IO.Path]::GetFullPath($guardRoot)
+  if ($resolvedRoot.StartsWith($tempBase, [StringComparison]::OrdinalIgnoreCase) -and
+      (Split-Path $resolvedRoot -Leaf).StartsWith('workdaddy-update-guard-')) {
+    Remove-Item -LiteralPath $resolvedRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+# The expected child PowerShell exit code is 1. Reset the workflow step result
+# after all assertions pass so pwsh does not propagate that native exit code.
+exit 0

--- a/.github/scripts/verify-windows-package.ps1
+++ b/.github/scripts/verify-windows-package.ps1
@@ -1,0 +1,40 @@
+param(
+  [Parameter(Mandatory = $true)][string]$ZipPath
+)
+
+$ErrorActionPreference = 'Stop'
+$zip = (Resolve-Path $ZipPath).Path
+$extractRoot = Join-Path ([IO.Path]::GetTempPath()) ('workdaddy-package-' + [guid]::NewGuid().ToString('N'))
+
+try {
+  Expand-Archive -LiteralPath $zip -DestinationPath $extractRoot -Force
+  foreach ($required in @(
+    'Install-WorkDaddy.cmd',
+    'Start-WorkDaddy.cmd',
+    'launcher.cmd',
+    'scripts\launcher-hidden.vbs',
+    'scripts\repair-entrypoints.ps1',
+    'scripts\daemon.js',
+    'scripts\node_modules\ws\package.json'
+  )) {
+    if (-not (Test-Path -LiteralPath (Join-Path $extractRoot $required) -PathType Leaf)) {
+      throw "zip missing $required"
+    }
+  }
+  if (Test-Path -LiteralPath (Join-Path $extractRoot 'scripts\Install-WorkDaddy.cmd')) {
+    throw 'zip contains duplicate scripts\Install-WorkDaddy.cmd entry'
+  }
+
+  $verify = Join-Path $extractRoot 'scripts\verify-win.cmd'
+  & cmd.exe /d /c ('call "' + $verify + '" --ci')
+  if ($LASTEXITCODE -ne 0) { throw "release verify failed: $LASTEXITCODE" }
+
+  Write-Output "Windows package passed: $zip"
+} finally {
+  $tempBase = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+  $resolvedRoot = [IO.Path]::GetFullPath($extractRoot)
+  if ($resolvedRoot.StartsWith($tempBase, [StringComparison]::OrdinalIgnoreCase) -and
+      (Split-Path $resolvedRoot -Leaf).StartsWith('workdaddy-package-')) {
+    Remove-Item -LiteralPath $resolvedRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,43 +1,58 @@
-name: Build & Verify Windows Setup
+name: Build & Verify Windows Release
 
-# 触发方式（任选其一都会跑这套打包+验证）：
-#   - 推 v* 标签（正式发版）
-#   - 手动触发（workflow_dispatch，可传版本号）
-#   - 推 master/main（可选，防回归）
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/build-win.yml'
+      - '.github/scripts/**'
+      - '.gitattributes'
+      - 'scripts/**'
   push:
     tags:
       - 'v*'
+      - '[0-9]*'
   workflow_dispatch:
     inputs:
       version:
-        description: '版本号（如 1.0.4），留空则从代码读取'
+        description: '版本号（如 1.0.6），留空则从代码读取'
         required: false
         default: ''
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build-and-verify:
-    name: Build zip + Setup.exe + verify
-    runs-on: windows-latest   # IExpress 是真 GUI，必须在 Windows runner 上打包
+  verify-windows:
+    name: Build zip + verify
+    runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: 校验 CRLF（cmd 必须 CRLF，否则 cmd.exe 解析括号块会失败）
+      - name: Use Node 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Verify line endings
         shell: bash
         run: |
-          for f in scripts/*.cmd; do
-            if ! grep -q $'\r' "$f"; then
-              echo "::error::$f 不是 CRLF，无法在 Windows 使用，请转换"
-              exit 1
-            fi
-          done
-          echo "所有 .cmd 均为 CRLF ✓"
+          python - <<'PY'
+          from pathlib import Path
+          errors = []
+          for path in Path('scripts').glob('*.cmd'):
+              data = path.read_bytes()
+              if b'\n' in data.replace(b'\r\n', b'') or b'\r' in data.replace(b'\r\n', b''):
+                  errors.append(f'{path} must use CRLF exclusively')
+          for path in Path('scripts').glob('*.sh'):
+              if b'\r' in path.read_bytes():
+                  errors.append(f'{path} must use LF exclusively')
+          for error in errors:
+              print(f'::error::{error}')
+          raise SystemExit(1 if errors else 0)
+          PY
 
-      - name: 解析版本号
+      - name: Resolve version
         id: ver
         shell: bash
         run: |
@@ -46,54 +61,56 @@ jobs:
             VER=$(grep -o "DAEMON_VERSION = '[^']*'" scripts/daemon.js | head -1 | cut -d"'" -f2)
           fi
           echo "version=$VER" >> "$GITHUB_OUTPUT"
-          echo "检测到版本: $VER"
+          echo "version=$VER"
 
-      - name: 打包内置资产 builtin（build-win-zip.sh 需要）
-        shell: bash
-        run: |
-          SRC="WorkDaddy.app/Contents/Resources/scripts/builtin"
-          if [ -d "$SRC" ]; then
-            cp -R "$SRC/." scripts/builtin/
-            echo "已复制 builtin 资产"
-          else
-            echo "警告: 未找到 builtin，面板将无官方壁纸（不影响安装功能）"
-          fi
-
-      - name: 生成 Windows zip
+      - name: Build Windows zip
         shell: bash
         run: bash scripts/build-win-zip.sh
 
-      - name: 生成 Setup.exe（IExpress 自解压安装包）
-        shell: cmd
-        run: |
-          call scripts\make-setup.cmd
+      - name: Verify final package
+        shell: pwsh
+        run: .\.github\scripts\verify-windows-package.ps1 -ZipPath "release\WorkDaddy-${{ steps.ver.outputs.version }}-win64.zip"
 
-      - name: 列出产物
-        shell: bash
-        run: ls -lh release/
+      - name: Verify local API contract
+        shell: pwsh
+        run: .\.github\scripts\verify-api-contract.ps1
 
-      - name: 产物完整性自检（verify-win.cmd，纯只读）
-        shell: cmd
-        run: |
-          call scripts\verify-win.cmd
+      - name: Verify update guard
+        shell: pwsh
+        run: .\.github\scripts\verify-update-guard.ps1
 
-      - name: 上传产物（zip + Setup.exe）
-        uses: actions/upload-artifact@v4
+      - name: Upload verified Windows zip
+        uses: actions/upload-artifact@v7
         with:
           name: workdaddy-win64
-          path: |
-            release/WorkDaddy-*-win64.zip
-            release/WorkDaddy-Setup.exe
-            release/WorkDaddy-Setup-*.exe
+          path: release/WorkDaddy-*-win64.zip
 
-      # ---- 只有打 tag 时才顺手挂到 GitHub Release ----
-      - name: 发布到 GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+  release-windows:
+    name: Publish Windows zip
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: verify-windows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download verified artifact
+        uses: actions/download-artifact@v8
         with:
-          files: |
-            release/WorkDaddy-*-win64.zip
-            release/WorkDaddy-Setup.exe
-            release/WorkDaddy-Setup-*.exe
-            release/*.dmg
+          name: workdaddy-win64
+          path: release
+
+      - name: Write asset checksum note
+        shell: bash
+        run: |
+          asset=$(find release -maxdepth 1 -type f -name 'WorkDaddy-*-win64.zip' -print -quit)
+          test -n "$asset"
+          name=$(basename "$asset")
+          digest=$(sha256sum "$asset" | cut -d' ' -f1)
+          printf 'SHA256 (%s): %s\n' "$name" "$digest" > release/checksums.md
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: release/WorkDaddy-*-win64.zip
+          body_path: release/checksums.md
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@
 ### Windows
 
 1. 在 [Releases](../../releases) 下载最新 `WorkDaddy-x.y.z-win64.zip`
-2. **解压到桌面以外的文件夹，双击一键安装脚本 `Install-WorkDaddy.cmd`**，安装后即可关闭该窗口：
-3. 以后只需**右键以管理员身份运行 WorkDaddy 图标** 即可
-4. 几秒后就会自动打开 WorkBuddy ，看到右下角机器人按钮即成功；
+2. **解压到桌面以外的文件夹，双击一键安装脚本 `Install-WorkDaddy.cmd`**，安装后即可关闭该窗口
+3. 以后只需双击桌面的 WorkDaddy 图标；正常用户目录安装无需管理员权限，也不会弹出命令行黑框
+4. 几秒后会自动打开 WorkBuddy/WorkBuddyAI，看到右下角机器人按钮即成功
+5. 如需排障，可手动运行安装目录里的 `scripts\launcher.cmd`
 
 
 ### 从源码运行（开发者）

--- a/scripts/Install-WorkDaddy.cmd
+++ b/scripts/Install-WorkDaddy.cmd
@@ -4,7 +4,7 @@ rem  WorkDaddy 一键安装（zip 解压后的顶层入口，双击运行）
 rem  作用：复制到 %LOCALAPPDATA%\Programs\WorkDaddy → 注册开机自启
 rem        → 创建桌面快捷方式 → 启动守护进程并以调试模式拉起 WorkBuddy
 rem  提示：本插件为 WorkBuddy 的增强工具，需先安装 WorkBuddy 桌面端。
-rem        运行所需的 Node 运行时由 WorkBuddy 自带托管（.workbuddy\binaries\node），
+rem        运行所需的 Node 运行时由 WorkBuddyAI/WorkBuddy 自带托管，
 rem        无需自行安装 Node.js。
 rem
 rem  设计：一律用"%~dp0"绝对路径定位，绝不做 cd 后相对调用——

--- a/scripts/apply-update.ps1
+++ b/scripts/apply-update.ps1
@@ -12,6 +12,10 @@ param(
 )
 
 $ErrorActionPreference = 'Continue'
+$appFull = [IO.Path]::GetFullPath($AppDir).TrimEnd('\')
+$rootFull = [IO.Path]::GetPathRoot($appFull).TrimEnd('\')
+if ([StringComparer]::OrdinalIgnoreCase.Equals($appFull, $rootFull)) { exit 3 }
+$AppDir = $appFull
 $DataDir = Join-Path $env:APPDATA 'WorkDaddy'
 $LogDir = Join-Path $DataDir 'update'
 New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
@@ -20,16 +24,54 @@ Start-Transcript -Path $Log -Append -Force
 
 Write-Host "[apply] $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') start src=$SrcZip dst=$AppDir"
 
-# 1) 杀 watchdog（会连带终止 daemon；PID 文件在数据目录）
+# 1) 先在独立临时目录解压并验证包结构，避免无效/错误 zip 触碰现有安装。
+$tmpDir = Join-Path $env:TEMP ("workdaddy-update-" + [guid]::NewGuid().ToString('N'))
+try {
+  if (-not (Test-Path -LiteralPath $SrcZip -PathType Leaf)) { throw '更新包不存在' }
+  New-Item -ItemType Directory -Force -Path $tmpDir -ErrorAction Stop | Out-Null
+  Expand-Archive -LiteralPath $SrcZip -DestinationPath $tmpDir -Force -ErrorAction Stop
+  foreach ($required in @(
+    'Install-WorkDaddy.cmd',
+    'Start-WorkDaddy.cmd',
+    'scripts\daemon.js',
+    'scripts\launcher.cmd',
+    'scripts\launcher-hidden.vbs',
+    'scripts\repair-entrypoints.ps1'
+  )) {
+    if (-not (Test-Path -LiteralPath (Join-Path $tmpDir $required) -PathType Leaf)) {
+      throw "更新包缺少 $required"
+    }
+  }
+  $srcRoot = $tmpDir
+} catch {
+  Write-Host "[apply] 更新包验证失败: $($_.Exception.Message)"
+  Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+  Stop-Transcript
+  exit 1
+}
+
+# 2) 杀 watchdog（会连带终止 daemon；PID 文件在数据目录）
 $pidFile = Join-Path $DataDir 'watchdog.pid'
 if (Test-Path $pidFile) {
   try {
-    $wpid = [int]((Get-Content $pidFile -Raw).Trim())
-    if ($wpid -gt 0) { taskkill /F /T /PID $wpid 2>$null | Out-Null }
+    $watchdogPid = [int]((Get-Content -LiteralPath $pidFile -Raw).Trim())
+    $watchdog = Get-CimInstance Win32_Process -Filter "ProcessId=$watchdogPid" -ErrorAction SilentlyContinue
+    $expectedWatchdog = (Join-Path $AppDir 'scripts\watchdog.js').ToLowerInvariant()
+    if ($watchdog -and $watchdog.CommandLine -and $watchdog.CommandLine.ToLowerInvariant().Contains($expectedWatchdog)) {
+      taskkill /F /T /PID $watchdogPid 2>$null | Out-Null
+    }
   } catch {}
 }
 
-# 2) 兜底：按 API 端口杀残留进程
+# 2.5) 清理属于当前安装目录的旧交互式 launcher。
+try {
+  $oldLauncher = (Join-Path $AppDir 'scripts\launcher.cmd').ToLowerInvariant()
+  Get-CimInstance Win32_Process -Filter "Name='cmd.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -and $_.CommandLine.ToLowerInvariant().Contains($oldLauncher) } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+} catch {}
+
+# 3) 兜底：按 API 端口杀残留进程
 $waitSec = 0
 while ($waitSec -lt 30) {
   $listening = netstat -ano | Select-String (":$Port\s") | Select-String 'LISTENING'
@@ -41,36 +83,33 @@ while ($waitSec -lt 30) {
 foreach ($line in (netstat -ano | Select-String (":$Port\s") | Select-String 'LISTENING')) {
   $parts = ($line.ToString().Trim() -split '\s+')
   $pid2 = $parts[$parts.Count - 1]
-  if ($pid2 -match '^\d+$') { taskkill /F /T /PID $pid2 2>$null | Out-Null }
+  if ($pid2 -match '^\d+$') {
+    $listener = Get-CimInstance Win32_Process -Filter "ProcessId=$pid2" -ErrorAction SilentlyContinue
+    $expectedDaemon = (Join-Path $AppDir 'scripts\daemon.js').ToLowerInvariant()
+    if ($listener -and $listener.CommandLine -and $listener.CommandLine.ToLowerInvariant().Contains($expectedDaemon)) {
+      taskkill /F /T /PID $pid2 2>$null | Out-Null
+    }
+  }
 }
 Start-Sleep -Seconds 1
 
-# 3) 备份旧目录（回滚：move AppDir.old AppDir）
+# 4) 备份旧目录（回滚：move AppDir.old AppDir）
 $oldDir = $AppDir + '.old'
-if (Test-Path $oldDir) { Remove-Item -Recurse -Force $oldDir -ErrorAction SilentlyContinue }
-if (Test-Path $AppDir) { Move-Item -Force $AppDir $oldDir -ErrorAction SilentlyContinue }
-
-# 4) 解压新版到临时目录，再移动到位（Expand-Archive 无法原地覆盖已存在目录）
-$tmpDir = Join-Path $env:TEMP ("workdaddy-update-" + [guid]::NewGuid().ToString('N'))
-New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
 try {
-  Expand-Archive -Path $SrcZip -DestinationPath $tmpDir -Force
+  if (Test-Path -LiteralPath $oldDir) { Remove-Item -LiteralPath $oldDir -Recurse -Force -ErrorAction Stop }
+  if (Test-Path -LiteralPath $AppDir) { Move-Item -LiteralPath $AppDir -Destination $oldDir -Force -ErrorAction Stop }
+  New-Item -ItemType Directory -Force -Path $AppDir -ErrorAction Stop | Out-Null
 } catch {
-  Write-Host "[apply] 解压失败: $($_.Exception.Message)"
-  if (Test-Path $oldDir) { Move-Item -Force $oldDir $AppDir -ErrorAction SilentlyContinue }  # 回滚
+  Write-Host "[apply] 备份旧版本失败: $($_.Exception.Message)"
+  if (-not (Test-Path -LiteralPath $AppDir) -and (Test-Path -LiteralPath $oldDir)) {
+    Move-Item -LiteralPath $oldDir -Destination $AppDir -Force -ErrorAction SilentlyContinue
+  }
+  Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
   Stop-Transcript
-  exit 1
+  exit 2
 }
 
-# 定位 zip 内的应用根：顶层含 scripts\daemon.js（打包结构）→ 顶层即根；个别情况顶层直接是文件
-$srcRoot = $tmpDir
-if (-not (Test-Path (Join-Path $tmpDir 'scripts\daemon.js')) -and -not (Test-Path (Join-Path $tmpDir 'daemon.js'))) {
-  $hit = Get-ChildItem $tmpDir -Recurse -Filter 'daemon.js' -ErrorAction SilentlyContinue | Select-Object -First 1
-  if ($hit) { $srcRoot = Split-Path $hit.FullName -Parent }
-}
-New-Item -ItemType Directory -Force -Path $AppDir | Out-Null
-
-# 复制内容（robocopy /MIR 保留结构；失败则回滚）
+# 5) 复制内容（robocopy /MIR 保留结构；失败则回滚）
 $rc = 1
 robocopy $srcRoot $AppDir /MIR /NFL /NDL /NJH /NJS /NP
 $rc = $LASTEXITCODE  # robocopy 0-7 都算成功
@@ -79,21 +118,53 @@ if ($rc -ge 8) {
   Remove-Item -Recurse -Force $AppDir -ErrorAction SilentlyContinue
   if (Test-Path $oldDir) { Move-Item -Force $oldDir $AppDir }
   Stop-Transcript
-  exit 2
+  Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+  exit 3
 }
 
-# 5) 清理备份 + 拉起（launcher 幂等：检测 daemon 后启动 watchdog）
-Remove-Item -Recurse -Force $oldDir -ErrorAction SilentlyContinue
-$launcher = Join-Path $AppDir 'launcher.cmd'
-$launcherVbs = Join-Path $AppDir 'launcher-hidden.vbs'
-if (Test-Path $launcher) {
-  if (Test-Path $launcherVbs) {
-    # wscript.exe 不创建控制台，自动更新重启时也不再弹出空白 Windows Terminal。
-    Start-Process -FilePath (Join-Path $env:WINDIR 'System32\wscript.exe') -ArgumentList ('//nologo "' + $launcherVbs + '"') -WorkingDirectory (Split-Path $launcher)
-  } else {
-    # 兼容旧版本目录：直接启动 launcher.cmd。
-    Start-Process -FilePath $launcher -WorkingDirectory (Split-Path $launcher)
+# 6) 修复静默入口并拉起新版；确认 /healthz 后才删除回滚目录。
+$targetScripts = Join-Path $AppDir 'scripts'
+$launcher = Join-Path $targetScripts 'launcher.cmd'
+$launcherVbs = Join-Path $targetScripts 'launcher-hidden.vbs'
+$repairEntrypoints = Join-Path $targetScripts 'repair-entrypoints.ps1'
+$wscript = Join-Path $env:WINDIR 'System32\wscript.exe'
+if (Test-Path -LiteralPath $repairEntrypoints -PathType Leaf) {
+  try { & $repairEntrypoints -AppDir $AppDir } catch { Write-Host ('[apply] 修复静默入口失败: ' + $_.Exception.Message) }
+}
+if (Test-Path -LiteralPath $launcherVbs -PathType Leaf) {
+  Start-Process -FilePath $wscript -ArgumentList ('//B //Nologo "' + $launcherVbs + '"') -WorkingDirectory $targetScripts -WindowStyle Hidden
+} elseif (Test-Path -LiteralPath $launcher -PathType Leaf) {
+  Start-Process -FilePath $launcher -WorkingDirectory $targetScripts -WindowStyle Hidden
+}
+
+$ready = $false
+for ($attempt = 0; $attempt -lt 30 -and -not $ready; $attempt++) {
+  Start-Sleep -Seconds 1
+  for ($candidate = [int]$Port; $candidate -lt ([int]$Port + 8); $candidate++) {
+    try {
+      $health = Invoke-RestMethod -Uri ("http://127.0.0.1:$candidate/healthz") -TimeoutSec 1
+      if ($health.ok -and $health.service -eq 'workdaddy') { $ready = $true; break }
+    } catch {}
   }
+}
+
+if ($ready) {
+  Remove-Item -LiteralPath $oldDir -Recurse -Force -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+} else {
+  Write-Host '[apply] 新版未通过健康检查，正在回滚旧版本'
+  Remove-Item -LiteralPath $AppDir -Recurse -Force -ErrorAction SilentlyContinue
+  if (Test-Path -LiteralPath $oldDir) { Move-Item -LiteralPath $oldDir -Destination $AppDir -Force }
+  Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+  $rollbackVbs = Join-Path $AppDir 'scripts\launcher-hidden.vbs'
+  $rollbackCmd = Join-Path $AppDir 'scripts\launcher.cmd'
+  if (Test-Path -LiteralPath $rollbackVbs -PathType Leaf) {
+    Start-Process -FilePath $wscript -ArgumentList ('//B //Nologo "' + $rollbackVbs + '"') -WindowStyle Hidden
+  } elseif (Test-Path -LiteralPath $rollbackCmd -PathType Leaf) {
+    Start-Process -FilePath $rollbackCmd -WorkingDirectory (Split-Path $rollbackCmd) -WindowStyle Hidden
+  }
+  Stop-Transcript
+  exit 4
 }
 Write-Host "[apply] $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') done"
 Stop-Transcript

--- a/scripts/build-win-zip.sh
+++ b/scripts/build-win-zip.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# WorkDaddy Windows 发布包打包脚本（在 macOS/Linux 上运行即可产出 Windows zip）
+# WorkDaddy Windows 发布包打包脚本（在 macOS/Linux/Git Bash 上运行即可产出 Windows zip）
 # 产出：release/WorkDaddy-<ver>-win64.zip（顶层含 scripts\，供 install-win.cmd / apply-update.ps1 使用）
 # 可选：内置 node_modules/ws（面板 DevTools 代理依赖；无则代理功能降级，其余功能不受影响）
 set -euo pipefail
@@ -13,64 +13,82 @@ OUT="release/WorkDaddy-${VERSION}-win64.zip"
 echo "==> 版本: ${VERSION}"
 echo "==> 产物: ${OUT}"
 
-# 1) 内置 ws（面板 DevTools 代理需要）；已存在则跳过
-if [ ! -d scripts/node_modules/ws ]; then
-  echo "==> 生成 node_modules/ws（DevTools 代理依赖）"
-  TMPNODE="$(mktemp -d)"
-  (cd "$TMPNODE" && npm init -y >/dev/null 2>&1 && npm install ws --no-audit --no-fund >/dev/null 2>&1)
-  mkdir -p scripts/node_modules
-  rm -rf scripts/node_modules/ws
-  mv "$TMPNODE/node_modules/ws" scripts/node_modules/ws
-  rm -rf "$TMPNODE"
+STAGE="$(mktemp -d)"
+TMPNODE=""
+cleanup() {
+  rm -rf "$STAGE"
+  if [ -n "$TMPNODE" ]; then rm -rf "$TMPNODE"; fi
+}
+trap cleanup EXIT
+
+# 1) 内置资产来源（若本次 checkout 没有 macOS app，则 Windows 包按无内置壁纸模式发布）。
+BUILTIN_SRC="$DIR/WorkDaddy.app/Contents/Resources/scripts/builtin"
+
+# 2) 打包：staging 目录，把两个顶层入口文件 + scripts/ 一起打进 zip 根（解压即见一键安装/启动）
+#    注意 apply-update.ps1 复用本结构（需 zip 内存在 scripts\daemon.js 做 srcRoot 判定）
+mkdir -p "$(dirname "$OUT")"
+rm -f "$OUT"
+# 2.1) 顶层入口（zip 根）：Install-WorkDaddy.cmd / Start-WorkDaddy.cmd
+cp scripts/Install-WorkDaddy.cmd "$STAGE/Install-WorkDaddy.cmd"
+cp scripts/Start-WorkDaddy.cmd "$STAGE/Start-WorkDaddy.cmd"
+# 兼容 1.0.5 updater：旧版更新完成后固定寻找 <AppDir>\launcher.cmd。
+printf '%s\r\n' \
+  '@echo off' \
+  'setlocal' \
+  'if exist "%~dp0scripts\repair-entrypoints.ps1" powershell -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "%~dp0scripts\repair-entrypoints.ps1" -AppDir "%~dp0"' \
+  'if exist "%~dp0scripts\launcher-hidden.vbs" start "" /b wscript.exe //B //Nologo "%~dp0scripts\launcher-hidden.vbs"' \
+  'exit /b 0' > "$STAGE/launcher.cmd"
+# 2.2) scripts\ 本体
+cp -R scripts "$STAGE/scripts"
+
+# 2.3) 只在 staging 内补齐 ws，避免打包污染仓库工作树。
+if [ ! -d "$STAGE/scripts/node_modules/ws" ]; then
+  mkdir -p "$STAGE/scripts/node_modules"
+  if [ -n "${WORKDADDY_WS_SOURCE:-}" ] && [ -d "$WORKDADDY_WS_SOURCE" ]; then
+    echo "==> 从 WORKDADDY_WS_SOURCE 复制 ws 到 staging"
+    cp -R "$WORKDADDY_WS_SOURCE" "$STAGE/scripts/node_modules/ws"
+  else
+    echo "==> 生成 staging/node_modules/ws（DevTools 代理依赖）"
+    TMPNODE="$(mktemp -d)"
+    (cd "$TMPNODE" && npm init -y >/dev/null 2>&1 && npm install ws --no-audit --no-fund >/dev/null 2>&1)
+    mv "$TMPNODE/node_modules/ws" "$STAGE/scripts/node_modules/ws"
+  fi
 fi
 
-# 2) 内置资产（官方壁纸 + nebula 主题，单一来源：WorkDaddy.app/Contents/Resources/scripts/builtin）
-#    仓库 scripts/ 本身不含 builtin，必须从 app 打包产物复制，否则 Windows 面板会显示「暂无官方壁纸」
-BUILTIN_SRC="$DIR/WorkDaddy.app/Contents/Resources/scripts/builtin"
+# 2.4) 内置资产也直接复制到 staging。
 if [ -d "$BUILTIN_SRC" ]; then
-  echo "==> 内置资产 builtin -> scripts/builtin（$(find "$BUILTIN_SRC/wallpapers" -name '*.webp' | wc -l | tr -d ' ') 张壁纸 + 主题）"
-  mkdir -p scripts/builtin
-  cp -R "$BUILTIN_SRC/." scripts/builtin/
+  echo "==> 内置资产 builtin（$(find "$BUILTIN_SRC/wallpapers" -name '*.webp' | wc -l | tr -d ' ') 张壁纸 + 主题）"
+  mkdir -p "$STAGE/scripts/builtin"
+  cp -R "$BUILTIN_SRC/." "$STAGE/scripts/builtin/"
 else
   echo "==> 警告: 未找到内置资产 $BUILTIN_SRC（无 WorkDaddy.app？），打包将不含官方壁纸/主题"
 fi
 
-# 3) 打包：staging 目录，把两个顶层入口文件 + scripts/ 一起打进 zip 根（解压即见一键安装/启动）
-#    注意 apply-update.ps1 复用本结构（需 zip 内存在 scripts\daemon.js 做 srcRoot 判定）
-STAGE="$(mktemp -d)"
-rm -f "$OUT"
-# 3.1) 顶层入口（zip 根）：Install-WorkDaddy.cmd / Start-WorkDaddy.cmd
-cp scripts/Install-WorkDaddy.cmd "$STAGE/Install-WorkDaddy.cmd"
-cp scripts/Start-WorkDaddy.cmd "$STAGE/Start-WorkDaddy.cmd"
-# 3.2) scripts\ 本体（含 node_modules/ws、builtin）
-cp -R scripts "$STAGE/scripts"
-# 3.2a) Logo 图标：放入 scripts\（install-win.ps1 从 SrcDir 同名找并复制到安装目录根）
+# 2.5) Logo 图标：放入 scripts\（install-win.ps1 从 SrcDir 同名找并复制到安装目录根）
 if [ -f "$DIR/release/WorkDaddy.ico" ]; then
   cp "$DIR/release/WorkDaddy.ico" "$STAGE/scripts/WorkDaddy.ico"
   echo "==> 内置 logo 图标 -> scripts/WorkDaddy.ico"
 else
   echo "==> 警告: 未找到 release/WorkDaddy.ico，桌面图标将回退为 cmd 默认"
 fi
-# 3.3) 排除开发/临时文件 + 顶层入口在 scripts\ 内的重复副本
+# 2.6) 排除开发/临时文件 + 顶层入口在 scripts\ 内的重复副本
 #      （Install-WorkDaddy.cmd / Start-WorkDaddy.cmd 只应存在于 zip 根，避免用户误进
 #       scripts\ 双击导致相对路径解析成 scripts\scripts\install-win.ps1 报错）
 rm -rf "$STAGE/scripts/win/probe" "$STAGE/scripts/win/probe/"* 2>/dev/null || true
 rm -f "$STAGE/scripts/Install-WorkDaddy.cmd" "$STAGE/scripts/Start-WorkDaddy.cmd" 2>/dev/null || true
 find "$STAGE" -name '*.log' -delete 2>/dev/null || true
 find "$STAGE" -name '.DS_Store' -delete 2>/dev/null || true
-# 3.4) 打包：zip 优先；无 zip 的环境用 Windows 系统自带 bsdtar（生成标准 / 分隔符 zip）。
+# 2.7) 打包：zip 优先；无 zip 时用 Python 标准库生成标准 / 分隔符 zip。
 #      绝不用 PowerShell Compress-Archive —— 它产出反斜杠分隔符，非标准 zip 会被解压工具把
 #      scripts\daemon.js 当单个文件名，导致解压结构错乱、入口秒退。
+PYTHON_BIN="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
 if command -v zip >/dev/null 2>&1; then
   (cd "$STAGE" && zip -r -q "$DIR/$OUT" .)
+elif [ -n "$PYTHON_BIN" ]; then
+  "$PYTHON_BIN" -c 'import os,sys,zipfile; root,out=sys.argv[1],sys.argv[2]; z=zipfile.ZipFile(out,"w",zipfile.ZIP_DEFLATED); [z.write(os.path.join(dp,f), os.path.relpath(os.path.join(dp,f),root).replace(os.sep,"/")) for dp,_,fs in os.walk(root) for f in fs]; z.close()' "$STAGE" "$DIR/$OUT"
 else
-  tar -a -cf "$DIR/$OUT" -C "$STAGE" .
-fi
-rm -rf "$STAGE"
-
-# 4) 清理临时内置到 scripts/ 的 builtin（避免污染仓库）
-if [ -d "$BUILTIN_SRC" ] && [ -d scripts/builtin ]; then
-  rm -rf scripts/builtin
+  echo "==> 错误: 未找到 zip / python3 / python，无法生成标准 ZIP"
+  exit 1
 fi
 
 echo "==> 完成: $(ls -lh "$OUT" | awk '{print $5}')"

--- a/scripts/daemon.js
+++ b/scripts/daemon.js
@@ -35,6 +35,7 @@ try { wsLib = require('ws'); } catch (_) {
     path.join(__dirname, 'node_modules', 'ws'),
     path.join(__dirname, '..', '..', 'scripts', 'node_modules', 'ws'),
     '/Users/h/.workbuddy/binaries/node/workspace/node_modules/ws',
+    path.join(os.homedir(), '.workbuddy-ai', 'binaries', 'node', 'workspace', 'node_modules', 'ws'),
     path.join(os.homedir(), '.workbuddy', 'binaries', 'node', 'workspace', 'node_modules', 'ws'),
   ];
   for (const c of cands) {
@@ -71,14 +72,11 @@ const DATA_DIR = defaultDataDir();
 // 1.0.5：修复自动更新「缺少解包后的新应用」——下载阶段只落 .dmg 从未解包，
 //       applyUpdate 现改为在安装前调用 extractAppFromDmg 解出 WorkDaddy.app（幂等），
 //       解包函数亦增强（清理残留挂载点、只读挂载、校验 dmg 内存在 WorkDaddy.app）
-// 1.0.6：daemon 单实例锁、启动竞态修复、注入结果校验与本地诊断快照
-// 1.0.7：兼容无全局 WebSocket 的 Node 18/20，使用内置 ws 建立 CDP
-// 1.0.8：去除 launchd 重定向造成的重复日志，并记录 launcher 选择的 Node 运行时
-// 1.0.9：诊断快照中的常见 token 字段脱敏
-// 1.0.10：daemon.log 按 10 MB 滚动保留最近 3 份，避免长期运行无限增长
-// 发布版本保持 1.0.5；build id 用于同版本修复包强制替换旧 daemon。
-const DAEMON_VERSION = '1.0.5';
-const DAEMON_BUILD_ID = 'accounts-migration-fix-20260820';
+// 1.0.5 发布后已合入：daemon 单实例/诊断/日志滚动、Node 18/20 WebSocket 兼容等修复。
+// 1.0.6：打包上述修复，并增加 WorkBuddyAI 5.3.x 路径兼容、Windows 静默可靠启动、
+//        本地 API 令牌与按资产 SHA-256 更新校验。
+const DAEMON_VERSION = '1.0.6';
+const DAEMON_BUILD_ID = 'workbuddyai-windows-hardening-20260821';
 const HOST = '127.0.0.1';
 const IS_WIN = process.platform === 'win32'; // Windows 移植：平台分支开关（macOS 行为保持不变）
 // Windows 安装目录（install.ps1 铺、launcher 用、更新替换目标），对应 macOS 的 /Applications/WorkDaddy.app
@@ -89,6 +87,7 @@ let ACTUAL_PORT = UI_PORT_BASE; // 实际监听端口（被占用时 +1）
 const CDP_PORT_HINT = process.env.WBSWITCH_CDP_PORT
   ? parseInt(process.env.WBSWITCH_CDP_PORT, 10)
   : null;
+const API_TOKEN_FILE = path.join(DATA_DIR, 'api-token');
 const WATCH_INTERVAL = 3000; // 文件监听兜底
 const BACKUP_DEBOUNCE = 1500; // CDP 事件触发的备份防抖
 const CDP_RECONNECT_MS = 5000;
@@ -113,9 +112,24 @@ const updateState = {
   progress: 0, // 0-100
   message: '',
   error: null,
+  sha256: null,
   checkedAt: 0,
 };
 let updateTimer = null;
+
+function ensureApiToken() {
+  try {
+    const existing = fs.readFileSync(API_TOKEN_FILE, 'utf8').trim();
+    if (/^[a-f0-9]{64}$/i.test(existing)) return existing;
+  } catch (_) {}
+  fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
+  const token = crypto.randomBytes(32).toString('hex');
+  fs.writeFileSync(API_TOKEN_FILE, token, { mode: 0o600 });
+  try { fs.chmodSync(API_TOKEN_FILE, 0o600); } catch (_) {}
+  return token;
+}
+
+const API_TOKEN = ensureApiToken();
 
 // 简单 semver 比较：a > b → 1，a < b → -1，相等 → 0（忽略预发布后缀）
 function semverCompare(a, b) {
@@ -143,10 +157,18 @@ function httpsGet(url, timeoutMs) {
   });
 }
 
-// 从 Release body 解析 SHA-256（发布时把 `SHA256: <hex>` 写进 Release notes）
-function parseSha256(body) {
+// 从 Release body 解析某个资产的 SHA-256；多资产 Release 必须使用带文件名格式，
+// 避免把 Windows zip 的摘要误用于 macOS dmg（或反过来）。
+function parseSha256(body, assetName) {
   if (!body) return null;
-  const m = String(body).match(/SHA-?256[:：]\s*([a-fA-F0-9]{64})/);
+  const text = String(body);
+  if (assetName) {
+    const escaped = String(assetName).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const named = text.match(new RegExp('SHA-?256\\s*\\(\\s*' + escaped + '\\s*\\)\\s*[:：=]\\s*([a-fA-F0-9]{64})', 'i')) ||
+      text.match(new RegExp('([a-fA-F0-9]{64})\\s+\\*?' + escaped + '(?:\\s|$)', 'i'));
+    if (named) return named[1].toLowerCase();
+  }
+  const m = text.match(/SHA-?256[:：]\s*([a-fA-F0-9]{64})/i);
   return m ? m[1].toLowerCase() : null;
 }
 
@@ -180,10 +202,13 @@ function checkUpdate(force) {
         : (assets.find((a) => /\.dmg$/i.test(a.name || '')) || null);
       updateState.dmgUrl = asset ? asset.browser_download_url : null;
       updateState.dmgSize = asset ? asset.size : 0;
+      updateState.sha256 = asset && /^sha256:[a-f0-9]{64}$/i.test(asset.digest || '')
+        ? String(asset.digest).slice(7).toLowerCase()
+        : (asset ? (parseSha256(updateState.notes, asset.name) || (assets.length === 1 ? parseSha256(updateState.notes) : null)) : null);
       updateState.checkedAt = Date.now();
       updateState.status = 'idle';
       updateState.message = updateState.hasUpdate ? '发现新版本 v' + latest : '已是最新版本';
-      try { fs.writeFileSync(UPDATE_CHECK_CACHE, JSON.stringify({ latest, hasUpdate: updateState.hasUpdate, dmgUrl: updateState.dmgUrl, dmgSize: updateState.dmgSize, notes: updateState.notes, checkedAt: updateState.checkedAt })); } catch (_) {}
+      try { fs.writeFileSync(UPDATE_CHECK_CACHE, JSON.stringify({ latest, hasUpdate: updateState.hasUpdate, dmgUrl: updateState.dmgUrl, dmgSize: updateState.dmgSize, sha256: updateState.sha256, notes: updateState.notes, checkedAt: updateState.checkedAt })); } catch (_) {}
       log(`[update] 检查完成: latest=${latest} hasUpdate=${updateState.hasUpdate} (current=${DAEMON_VERSION})`);
       return updateState;
     })
@@ -198,6 +223,7 @@ function checkUpdate(force) {
         updateState.latest = c.latest;
         updateState.hasUpdate = !!c.hasUpdate;
         updateState.dmgUrl = c.dmgUrl;
+        updateState.sha256 = c.sha256 || null;
         updateState.notes = c.notes;
         updateState.checkedAt = c.checkedAt || Date.now();
       } catch (_) {}
@@ -214,8 +240,9 @@ function downloadUpdate() {
   if (fs.existsSync(target)) {
     // 已有同版本文件：直接校验后复用
     const digest = sha256File(target);
-    const expect = parseSha256(updateState.notes);
-    if (!expect || digest === expect) {
+    const expect = updateState.sha256;
+    if (!expect) return Promise.reject(new Error('Release 未提供 SHA-256，已拒绝安装未校验更新'));
+    if (digest === expect) {
       updateState.downloaded = true;
       updateState.progress = 100;
       updateState.status = 'idle';
@@ -253,8 +280,15 @@ function downloadUpdate() {
         updateState.status = 'verifying';
         updateState.message = '校验安装包…';
         const digest = sha256File(target);
-        const expect = parseSha256(updateState.notes);
-        if (expect && digest !== expect) {
+        const expect = updateState.sha256;
+        if (!expect) {
+          fs.unlinkSync(target);
+          updateState.status = 'error';
+          updateState.error = 'Release 未提供 SHA-256';
+          updateState.message = '缺少校验值，已拒绝安装';
+          return reject(new Error('Release 未提供 SHA-256，已拒绝安装未校验更新'));
+        }
+        if (digest !== expect) {
           fs.unlinkSync(target);
           updateState.status = 'error';
           updateState.error = 'SHA-256 校验失败';
@@ -263,7 +297,7 @@ function downloadUpdate() {
         }
         updateState.downloaded = true;
         updateState.status = 'idle';
-        updateState.message = '安装包已就绪' + (expect ? '（校验通过）' : '（未校验）');
+        updateState.message = '安装包已就绪（SHA-256 校验通过）';
         log(`[update] 下载完成 ${target} sha256=${digest}`);
         resolve(target);
       });
@@ -494,9 +528,9 @@ function isWorkBuddyCdpTarget(target) {
   if (!target || target.type !== 'page') return false;
   const url = String(target.url || '');
   const title = String(target.title || '');
-  return /(?:^|\/)WorkBuddy\.app(?:\/|$)/i.test(url) ||
+  return /(?:^|\/)WorkBuddy(?:AI)?\.app(?:\/|$)/i.test(url) ||
     /https?:\/\/(?:[^/]+\.)?(?:workbuddy|codebuddy)\.cn(?:\/|$)/i.test(url) ||
-    /^WorkBuddy(?:\s|$)/i.test(title);
+    /^WorkBuddy(?:AI)?(?:\s|$)/i.test(title);
 }
 
 async function getPageTarget(port) {
@@ -721,7 +755,7 @@ async function reloadWorkBuddyPage() {
 const WORKBUDDY_APP = IS_WIN ? '' : '/Applications/WorkBuddy.app';
 const WORKBUDDY_BINARY = IS_WIN ? '' : `${WORKBUDDY_APP}/Contents/MacOS/Electron`;
 
-// Windows：解析 WorkBuddy 可执行文件真实路径（安装盘可自定义，必须动态查）
+// Windows：解析 WorkBuddy/WorkBuddyAI 可执行文件真实路径（安装盘可自定义，必须动态查）
 // 优先级：WBSWITCH_WORKBUDDY_BIN > 运行进程 Path > 注册表卸载项 > 常见路径
 let wbBinaryCache = null;
 function resolveWorkBuddyBinary() {
@@ -733,22 +767,25 @@ function resolveWorkBuddyBinary() {
   // 1) 显式指定（launcher/install 传入最可靠）
   const envBin = tryFile(process.env.WBSWITCH_WORKBUDDY_BIN);
   if (envBin) return (wbBinaryCache = envBin);
-  // 2) 运行中的 WorkBuddy 进程 Path（最权威：多实例共享同一 exe）
+  // 2) 运行中的 WorkBuddy/WorkBuddyAI 进程 Path（最权威）
   try {
-    const out = psCmd('Get-Process WorkBuddy -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Path');
+    const out = psCmd('Get-Process WorkBuddyAI,WorkBuddy -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Path');
     const p = out.trim().split(/\r?\n/).filter(Boolean).pop();
     const hit = tryFile(p);
     if (hit) return (wbBinaryCache = hit);
   } catch (_) {}
-  // 3) 注册表卸载项（DisplayIcon = "D:\xxx\WorkBuddy.exe,0" 取逗号前）
+  // 3) 注册表卸载项（DisplayIcon 优先；InstallLocation 兼容两种进程名）
   try {
-    const out = psCmd("$k=@('HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'); Get-ItemProperty $k -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -match 'WorkBuddy|CodeBuddy' } | Select-Object -First 1 DisplayIcon,InstallLocation | ForEach-Object { if($_.DisplayIcon){ ($_.DisplayIcon -replace ',.*$','').Trim() } elseif($_.InstallLocation){ Join-Path $_.InstallLocation 'WorkBuddy.exe' } }");
+    const out = psCmd("$k=@('HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'); Get-ItemProperty $k -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -match 'WorkBuddy|CodeBuddy' } | Select-Object -First 1 DisplayIcon,InstallLocation | ForEach-Object { if($_.DisplayIcon){ ($_.DisplayIcon -replace ',.*$','').Trim() } elseif($_.InstallLocation){ $ai=Join-Path $_.InstallLocation 'WorkBuddyAI.exe'; $legacy=Join-Path $_.InstallLocation 'WorkBuddy.exe'; if(Test-Path $ai){$ai}else{$legacy} } }");
     const p = out.trim().split(/\r?\n/).filter(Boolean).pop();
     const hit = tryFile(p);
     if (hit) return (wbBinaryCache = hit);
   } catch (_) {}
   // 4) 常见路径兜底（含探测机实际安装位）
   const cands = [
+    path.join(process.env.LOCALAPPDATA || '', 'Programs', 'WorkBuddyAI', 'WorkBuddyAI.exe'),
+    path.join(process.env.ProgramFiles || '', 'WorkBuddyAI', 'WorkBuddyAI.exe'),
+    path.join(process.env['ProgramFiles(x86)'] || '', 'WorkBuddyAI', 'WorkBuddyAI.exe'),
     path.join(process.env.LOCALAPPDATA || '', 'Programs', 'WorkBuddy', 'WorkBuddy.exe'),
     path.join(process.env.ProgramFiles || '', 'WorkBuddy', 'WorkBuddy.exe'),
     path.join(process.env['ProgramFiles(x86)'] || '', 'WorkBuddy', 'WorkBuddy.exe'),
@@ -794,12 +831,13 @@ function runCommand(command, args, options = {}) {
 function workBuddyRunning() {
   try {
     if (IS_WIN) {
+      const imageName = path.basename(resolveWorkBuddyBinary() || '') || 'WorkBuddy.exe';
       const r = spawnSync(
         'tasklist',
-        ['/FI', 'IMAGENAME eq WorkBuddy.exe', '/FO', 'CSV', '/NH'],
+        ['/FI', 'IMAGENAME eq ' + imageName, '/FO', 'CSV', '/NH'],
         { encoding: 'utf8', timeout: 5000, windowsHide: true }
       );
-      return r.status === 0 && /"WorkBuddy\.exe"/i.test(r.stdout || '');
+      return r.status === 0 && (r.stdout || '').toLowerCase().includes('"' + imageName.toLowerCase() + '"');
     }
     const r = spawnSync('pgrep', ['-f', WORKBUDDY_APP], { stdio: 'ignore', timeout: 5000 });
     return r.status === 0;
@@ -819,8 +857,9 @@ async function waitForWorkBuddyExit(timeoutMs = 10000) {
 }
 
 async function elevatedWindowsKill() {
+  const imageName = path.basename(resolveWorkBuddyBinary() || '') || 'WorkBuddy.exe';
   const command =
-    "$p = Start-Process -FilePath 'taskkill.exe' -ArgumentList '/F','/T','/IM','WorkBuddy.exe' -Verb RunAs -Wait -PassThru; exit $p.ExitCode";
+    "$p = Start-Process -FilePath 'taskkill.exe' -ArgumentList '/F','/T','/IM','" + imageName.replace(/'/g, "''") + "' -Verb RunAs -Wait -PassThru; exit $p.ExitCode";
   return runCommand('powershell', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', command], { timeoutMs: 30000 });
 }
 
@@ -829,10 +868,11 @@ async function quitWorkBuddy() {
   if (!workBuddyRunning()) return true;
 
   if (IS_WIN) {
-    await runCommand('taskkill', ['/IM', 'WorkBuddy.exe']);
+    const imageName = path.basename(resolveWorkBuddyBinary() || '') || 'WorkBuddy.exe';
+    await runCommand('taskkill', ['/IM', imageName]);
     if (await waitForWorkBuddyExit(1800)) return true;
 
-    await runCommand('taskkill', ['/F', '/T', '/IM', 'WorkBuddy.exe']);
+    await runCommand('taskkill', ['/F', '/T', '/IM', imageName]);
     if (await waitForWorkBuddyExit(2500)) return true;
 
     // WorkBuddy 可能由管理员权限启动；普通 daemon 无法结束它时请求一次 UAC。
@@ -874,9 +914,10 @@ function relaunchWorkBuddy() {
   return new Promise((resolve, reject) => {
     if (IS_WIN) {
       const bin = resolveWorkBuddyBinary();
-      if (!bin) return reject(new Error('未找到 WorkBuddy.exe（可用环境变量 WBSWITCH_WORKBUDDY_BIN 指定）'));
-      log(`[logout] 以 --remote-debugging-port=9222 重启 WorkBuddy: ${bin}`);
-      const child = spawn(bin, ['--remote-debugging-port=9222'], { detached: true, stdio: 'ignore', windowsHide: true });
+      if (!bin) return reject(new Error('未找到 WorkBuddy/WorkBuddyAI 可执行文件（可用环境变量 WBSWITCH_WORKBUDDY_BIN 指定）'));
+      const port = CDP_PORT_HINT || cdp.port || 9222;
+      log(`[logout] 以 --remote-debugging-port=${port} 重启 WorkBuddy: ${bin}`);
+      const child = spawn(bin, ['--remote-debugging-port=' + port], { detached: true, stdio: 'ignore', windowsHide: true });
       child.on('error', (e) => reject(e));
       child.unref();
       return resolve();
@@ -1195,6 +1236,7 @@ function injectWidget(reason) {
   }
   // 组件内通过 fetch 调用本机 API，注入时写入实际端口
   script = script.replace(/__WBS_API__/g, `http://${HOST}:${ACTUAL_PORT}`);
+  script = script.replace(/__WBS_TOKEN__/g, API_TOKEN);
   // 同步注入当前 daemon 版本号（inject.js 顶部的 __WBS_VERSION__ 占位符会在面板「关于」页直接展示，
   // 这样版本升级后不需要改 inject.js、面板永远显示 daemon 的真实版本）
   script = script.replace(/__WBS_VERSION__/g, DAEMON_VERSION);
@@ -1316,8 +1358,16 @@ async function writeDiagnosticsSnapshot(reason) {
 /* ================= 本地 Web 服务 ================= */
 
 
-// ===== SESSIONS_API_MARK：会话管理（读 WorkBuddy workbuddy.db）=====
-const SESSIONS_DB = path.join(os.homedir(), '.workbuddy', 'workbuddy.db');
+// ===== SESSIONS_API_MARK：会话管理（读写 WorkBuddy workbuddy.db）=====
+function resolveWorkBuddyHome() {
+  if (process.env.WBSWITCH_WORKBUDDY_HOME) return process.env.WBSWITCH_WORKBUDDY_HOME;
+  const ai = path.join(os.homedir(), '.workbuddy-ai');
+  const legacy = path.join(os.homedir(), '.workbuddy');
+  if (fs.existsSync(path.join(ai, 'workbuddy.db')) || fs.existsSync(path.join(ai, 'app'))) return ai;
+  return legacy;
+}
+const WORKBUDDY_HOME = resolveWorkBuddyHome();
+const SESSIONS_DB = path.join(WORKBUDDY_HOME, 'workbuddy.db');
 // Windows：无系统 sqlite3 CLI，优先用 Node 内置 node:sqlite（需 --experimental-sqlite 启动，launcher/install 已统一加）
 let NodeSqlite = null;
 if (IS_WIN) { try { NodeSqlite = require('node:sqlite'); } catch (_) { NodeSqlite = null; } }
@@ -1331,6 +1381,7 @@ function sqliteRun(sql) {
     return new Promise((resolve, reject) => {
       let db = null;
       try {
+        if (!fs.existsSync(SESSIONS_DB)) throw new Error('数据库不存在: ' + SESSIONS_DB);
         const write = sqliteIsWrite(sql);
         db = new NodeSqlite.DatabaseSync(SESSIONS_DB, { readOnly: !write });
         if (write) {
@@ -1471,17 +1522,42 @@ function json(res, code, obj) {
 }
 
 function readBody(req) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let data = '';
-    req.on('data', (c) => (data += c));
+    let bytes = 0;
+    let tooLarge = false;
+    const maxBytes = 16 * 1024 * 1024;
+    req.on('data', (c) => {
+      if (tooLarge) return;
+      bytes += c.length;
+      if (bytes > maxBytes) {
+        tooLarge = true;
+        data = '';
+        return;
+      }
+      data += c;
+    });
     req.on('end', () => {
+      if (tooLarge) {
+        const error = new Error('请求体超过 16 MiB 限制');
+        error.statusCode = 413;
+        return reject(error);
+      }
       try {
         resolve(data ? JSON.parse(data) : {});
-      } catch (_) {
-        resolve({});
+      } catch (e) {
+        const error = new Error('请求体不是有效 JSON');
+        error.statusCode = 400;
+        reject(error);
       }
     });
   });
+}
+
+function validApiToken(value) {
+  const supplied = Buffer.from(String(value || ''), 'utf8');
+  const expected = Buffer.from(API_TOKEN, 'utf8');
+  return supplied.length === expected.length && crypto.timingSafeEqual(supplied, expected);
 }
 
 /* ================= 决策弹窗开关（全局自定义指令注入） =================
@@ -1506,7 +1582,7 @@ const ASK_MODE_RULE = [
 ].join('\n');
 
 function workbuddySettingsPath() {
-  return path.join(os.homedir(), '.workbuddy', 'settings.json');
+  return path.join(WORKBUDDY_HOME, 'settings.json');
 }
 
 function readWorkbuddySettings() {
@@ -2681,10 +2757,15 @@ function handleApi(req, res) {
     res.writeHead(204, {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Headers': 'Content-Type, X-WorkDaddy-Token',
+      'Access-Control-Allow-Private-Network': 'true',
       'Access-Control-Max-Age': '86400',
     });
     return res.end();
+  }
+
+  if (!validApiToken(req.headers['x-workdaddy-token'])) {
+    return json(res, 403, { ok: false, error: 'unauthorized' });
   }
 
   if (req.method === 'POST' && p === '/api/inject') {
@@ -3078,7 +3159,7 @@ function handleApi(req, res) {
         // 1) 取出源会话（含 cwd 用于定位消息文件）
         const srcRows = await sqliteQuery("SELECT id, cwd, user_id, title, custom_title, status, created_at, updated_at, last_activity_at, is_playground, source_mode, is_background_automation, mode, model, expert_id, expert_locale, expert_runtime_identity, expert_marketplace, permission_mode, use_sandbox_cli, project_id FROM sessions WHERE id IN (" + esc + ") AND deleted_at IS NULL;");
         if (!srcRows.length) return json(res, 404, { ok: false, error: '源会话不存在' });
-        const wbHome = path.join(os.homedir(), '.workbuddy');
+        const wbHome = WORKBUDDY_HOME;
         let copied = 0;
         for (const src of srcRows) {
           const newId = crypto.randomUUID();
@@ -3141,7 +3222,7 @@ function handleApi(req, res) {
         // 1) 真实删除 DB 记录（非软删）
         await sqliteRun("DELETE FROM sessions WHERE id IN (" + esc + ");");
         // 2) 删除本地消息文件（jsonl/目录/workspace/tasks/file-history/artifact-index）
-        const wbHome = path.join(os.homedir(), '.workbuddy');
+        const wbHome = WORKBUDDY_HOME;
         let filesRemoved = 0;
         for (const id of ids) filesRemoved += deleteSessionFiles(wbHome, id);
         log(`[sessions-delete] 已真实删除 ${ids.length} 个会话（DB + ${filesRemoved} 项文件）`);
@@ -3164,7 +3245,7 @@ function handleApi(req, res) {
   }
 
   // 打开 WorkBuddy 的 Chrome DevTools（绕开 chrome://inspect 404 + Electron CDP 拒绝带 Origin 的 WS）
-  // 前端页面从 9222 加载，ws 通过 daemon 代理（/devtools-proxy/<id>）中转去 Origin
+  // 前端页面从实际 CDP 端口加载，ws 通过带令牌的 daemon 代理中转。
   // 注意：必须 return Promise 立即返回，避免同步函数继续执行到 404 分支
   if (req.method === 'GET' && p === '/api/devtools-url') {
     return new Promise((resolve) => {
@@ -3180,7 +3261,8 @@ function handleApi(req, res) {
             const id = page && page.id;
             if (!id) return resolve(json(res, 500, { ok: false, error: '未找到 WorkBuddy 页面 target' }));
             if (!wsLib) return resolve(json(res, 500, { ok: false, error: 'ws 代理库未加载，无法打开 DevTools' }));
-            const url = 'http://127.0.0.1:' + devtoolsPort + '/devtools/inspector.html?ws=127.0.0.1:' + ACTUAL_PORT + '/devtools-proxy/' + id;
+            const wsTarget = '127.0.0.1:' + ACTUAL_PORT + '/devtools-proxy/' + id + '?token=' + encodeURIComponent(API_TOKEN);
+            const url = 'http://127.0.0.1:' + devtoolsPort + '/devtools/inspector.html?ws=' + encodeURIComponent(wsTarget);
             resolve(json(res, 200, { ok: true, url }));
           } catch (e) {
             resolve(json(res, 500, { ok: false, error: e.message }));
@@ -3727,7 +3809,26 @@ function restoreSleepMode() {
 
 function startServer() {
   const server = http.createServer((req, res) => {
-    if (req.url.startsWith('/api/')) return handleApi(req, res);
+    if (req.method === 'GET' && req.url.split('?')[0] === '/healthz') {
+      return json(res, 200, {
+        ok: true,
+        service: 'workdaddy',
+        version: DAEMON_VERSION,
+        buildId: DAEMON_BUILD_ID,
+        port: ACTUAL_PORT,
+      });
+    }
+    if (req.url.startsWith('/api/')) {
+      Promise.resolve(handleApi(req, res)).catch((e) => {
+        if (res.headersSent) {
+          try { res.end(); } catch (_) {}
+          return;
+        }
+        const code = e && (e.statusCode === 400 || e.statusCode === 413) ? e.statusCode : 500;
+        json(res, code, { ok: false, error: e && e.message ? e.message : 'internal error' });
+      });
+      return;
+    }
     // 官方背景图静态服务：/wallpapers/<name>（供面板「主题」页缩略图预览）
     if (req.method === 'GET' && /^\/wallpapers\//.test(req.url)) {
       try {
@@ -3765,19 +3866,21 @@ function startServer() {
     res.end('not found');
   });
 
-  // DevTools WebSocket 代理：/devtools-proxy/<targetId> —— 浏览器前端连 daemon（不校验 Origin），
-  // daemon 用无 Origin 的 WebSocket 连 9222 转发（Electron CDP 拒绝带 Origin 的连接）
+  // DevTools WebSocket 代理：浏览器前端连 daemon，daemon 再用无 Origin
+  // 的 WebSocket 连接实际 WorkBuddy CDP 端口。
   if (wsLib) {
     const { WebSocketServer } = wsLib;
     const wss = new WebSocketServer({ noServer: true });
     server.on('upgrade', (req, socket, head) => {
-      let pathname = '';
-      try { pathname = new URL(req.url, 'http://x').pathname; } catch (_) { socket.destroy(); return; }
-      const m = /^\/devtools-proxy\/([A-Za-z0-9]+)$/.exec(pathname);
+      let parsed;
+      try { parsed = new URL(req.url, 'http://x'); } catch (_) { socket.destroy(); return; }
+      if (!validApiToken(parsed.searchParams.get('token'))) { socket.destroy(); return; }
+      const m = /^\/devtools-proxy\/([A-Za-z0-9_-]+)$/.exec(parsed.pathname);
       if (!m) { socket.destroy(); return; }
       wss.handleUpgrade(req, socket, head, (front) => {
         if (!WebSocketCtor) { try { front.close(); } catch (_) {} return; }
-        const back = new WebSocketCtor('ws://127.0.0.1:9222/devtools/page/' + m[1]);
+        const devtoolsPort = cdp.port || CDP_PORT_HINT || 9222;
+        const back = new WebSocketCtor('ws://127.0.0.1:' + devtoolsPort + '/devtools/page/' + m[1]);
         let backReady = false;
         let keepAlive = null;
         const queue = [];

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -76,6 +76,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   try { console.log('[WBS] inject.js 已执行于', location.href, 'body=', !!document.body); } catch (_) {}
   if (window.__wbsWidget) return; // 理论上 cleanup 已清除，保留为兜底
   var API = '__WBS_API__';
+  var API_TOKEN = '__WBS_TOKEN__';
 
   // ===== 全局错误钩子：捕获渲染进程不可捕获的 error / unhandledrejection，把完整消息+栈
   // 打到 daemon 日志。渲染进程级崩溃（如 An object could not be cloned）虽非 try/catch 能拦，
@@ -93,7 +94,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
       var line = '[wbscrash] ' + kind + ': ' + msg + (stack ? '\n' + stack : '');
       try { console.error(line); } catch (_) {}
       try {
-        fetch(API + '/api/breadcrumb', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ msg: 'crash:' + kind + ':' + msg, extra: { stack: (stack || '').slice(0, 1500) } }) }).catch(function () {});
+        fetch(API + '/api/breadcrumb', { method: 'POST', headers: { 'content-type': 'application/json', 'X-WorkDaddy-Token': API_TOKEN }, body: JSON.stringify({ msg: 'crash:' + kind + ':' + msg, extra: { stack: (stack || '').slice(0, 1500) } }) }).catch(function () {});
       } catch (_) {}
     }
     window.addEventListener('error', function (ev) { wbsReportErr('error', ev); });
@@ -192,6 +193,10 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   }
 
   function api(path, opts) {
+    opts = opts || {};
+    var headers = opts.headers || {};
+    headers['X-WorkDaddy-Token'] = API_TOKEN;
+    opts.headers = headers;
     return fetch(API + path, opts).then(function (r) {
       return r.json().then(function (j) {
         if (!r.ok || j.ok === false) throw new Error(j.error || '请求失败');
@@ -1242,7 +1247,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     function crumb(msg) {
       try { console.log('[wbscrum]', msg); } catch (e) {}
       try {
-        fetch(API + '/api/breadcrumb', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ msg: msg }) }).catch(function () {});
+        fetch(API + '/api/breadcrumb', { method: 'POST', headers: { 'content-type': 'application/json', 'X-WorkDaddy-Token': API_TOKEN }, body: JSON.stringify({ msg: msg }) }).catch(function () {});
       } catch (e) {}
     }
     listen(stashBtn, 'click', function () {

--- a/scripts/install-win.ps1
+++ b/scripts/install-win.ps1
@@ -8,7 +8,15 @@ param(
 )
 
 $ErrorActionPreference = 'Continue'
+$appFull = [IO.Path]::GetFullPath($AppDir).TrimEnd('\')
+$rootFull = [IO.Path]::GetPathRoot($appFull).TrimEnd('\')
+if ([StringComparer]::OrdinalIgnoreCase.Equals($appFull, $rootFull)) {
+  Write-Host '错误：安装目录不能是驱动器根目录。'
+  exit 1
+}
+$AppDir = $appFull
 $targetScripts = Join-Path $AppDir 'scripts'
+$dataDir = Join-Path $env:APPDATA 'WorkDaddy'
 
 Write-Host '=============================================================='
 Write-Host ' WorkDaddy Windows 安装'
@@ -16,7 +24,27 @@ Write-Host '=============================================================='
 Write-Host ("  源目录   : " + $SrcDir)
 Write-Host ("  安装目录 : " + $AppDir)
 
-# 1) 复制（排除开发/临时文件；node_modules/ws 随包带入）
+# 1) 覆盖升级前停止属于当前安装目录的旧 WorkDaddy 进程。
+try {
+  $pidFile = Join-Path $dataDir 'watchdog.pid'
+  if (Test-Path -LiteralPath $pidFile -PathType Leaf) {
+    $watchdogPid = [int]((Get-Content -LiteralPath $pidFile -Raw).Trim())
+    $watchdog = Get-CimInstance Win32_Process -Filter "ProcessId=$watchdogPid" -ErrorAction SilentlyContinue
+    $expectedWatchdog = (Join-Path $targetScripts 'watchdog.js').ToLowerInvariant()
+    if ($watchdog -and $watchdog.CommandLine -and $watchdog.CommandLine.ToLowerInvariant().Contains($expectedWatchdog)) {
+      taskkill /F /T /PID $watchdogPid 2>$null | Out-Null
+    }
+  }
+} catch {}
+try {
+  $oldLauncher = (Join-Path $targetScripts 'launcher.cmd').ToLowerInvariant()
+  Get-CimInstance Win32_Process -Filter "Name='cmd.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -and $_.CommandLine.ToLowerInvariant().Contains($oldLauncher) } |
+    ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+} catch {}
+Start-Sleep -Milliseconds 500
+
+# 2) 镜像复制（目标固定为 <AppDir>\scripts，清理旧版本残留）。
 if (-not (Test-Path (Join-Path $SrcDir 'daemon.js'))) {
   Write-Host '错误：源目录中找不到 daemon.js，请从仓库 scripts/ 目录运行本脚本。'
   exit 1
@@ -29,7 +57,7 @@ if ([StringComparer]::OrdinalIgnoreCase.Equals($sourceFull, $targetFull)) {
   # 在 Windows 上容易出现“文件正被另一个进程使用”。此时只需继续执行后续注册/快捷方式步骤。
   Write-Host '  源目录与安装目录相同，跳过自拷贝。'
 } else {
-  robocopy $SrcDir $targetScripts /E /XF *.log .DS_Store /XD win\probe /R:2 /W:1
+  robocopy $SrcDir $targetScripts /MIR /XF *.log .DS_Store /XD win\probe /R:3 /W:1
   $rc = $LASTEXITCODE
   if ($rc -ge 8) {
     Write-Host "复制失败（robocopy=$rc）"
@@ -37,8 +65,7 @@ if ([StringComparer]::OrdinalIgnoreCase.Equals($sourceFull, $targetFull)) {
   }
 }
 
-# 2) 数据目录
-$dataDir = Join-Path $env:APPDATA 'WorkDaddy'
+# 3) 数据目录
 New-Item -ItemType Directory -Force -Path (Join-Path $dataDir 'accounts') | Out-Null
 
 # 2.5) Logo 图标：随安装复制到安装目录根（桌面快捷方式用），源在 scripts 同级的 WorkDaddy.ico
@@ -48,55 +75,24 @@ if (Test-Path $logoIcoSrc) {
   try { Copy-Item $logoIcoSrc $logoIco -Force; Write-Host ('  图标复制 : ' + $logoIco) } catch {}
 }
 
-# 3) 登录自启（HKCU Run，登录时自动跑 launcher.cmd；崩溃自愈由 watchdog 负责）
-$runKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+# 4) 创建/迁移静默入口（桌面快捷方式 + HKCU Run）。
 $launcher = Join-Path $targetScripts 'launcher.cmd'
-try {
-  Set-ItemProperty -Path $runKey -Name 'WorkDaddy' -Value ('"' + $launcher + '"')
-  Write-Host '  自启注册：HKCU\...\Run\WorkDaddy = ' $launcher
-} catch {
-  Write-Host ('  自启注册失败（可忽略，之后手动双击 launcher.cmd 即可）: ' + $_.Exception.Message)
-}
-
-# 4) 启动（daemon + 以 CDP 模式重启 WorkBuddy + 注入）
-Write-Host '  正在启动 WorkDaddy（如果 WorkBuddy 正在运行，会重启它以开启调试模式）...'
 $launcherVbs = Join-Path $targetScripts 'launcher-hidden.vbs'
-if (Test-Path $launcher) {
-  if (Test-Path $launcherVbs) {
-    Start-Process -FilePath (Join-Path $env:WINDIR 'System32\wscript.exe') -ArgumentList ('//nologo "' + $launcherVbs + '"') -WorkingDirectory (Split-Path $launcher)
-  } else {
-    Start-Process -FilePath $launcher -WorkingDirectory (Split-Path $launcher)
-  }
-} else {
-  Write-Host '  警告：launcher.cmd 不存在，跳过自动启动（请到安装目录手动双击）'
+$repairEntrypoints = Join-Path $targetScripts 'repair-entrypoints.ps1'
+try {
+  if (-not (Test-Path -LiteralPath $repairEntrypoints -PathType Leaf)) { throw 'repair-entrypoints.ps1 不存在' }
+  & $repairEntrypoints -AppDir $AppDir
+} catch {
+  Write-Host ('  静默入口创建失败（可手动运行 launcher.cmd）: ' + $_.Exception.Message)
 }
 
-# 5) 创建桌面快捷方式「WorkDaddy」
-#    优先使用 wscript.exe 隐藏入口，避免 Windows Terminal 为管理员 cmd 创建空白窗口；
-#    缺少隐藏入口时回退到 cmd.exe，兼容旧包/手工安装目录。
-$desktopDir = [Environment]::GetFolderPath('Desktop')
-if (-not $desktopDir) { $desktopDir = Join-Path $env:USERPROFILE 'Desktop' }
-$lnkPath = Join-Path $desktopDir 'WorkDaddy.lnk'
-# Logo 图标（macOS 版同款黑白的 WorkBuddy 机器人，打包时置于安装目录根）
-$logoIco = Join-Path $AppDir 'WorkDaddy.ico'
-try {
-  $ws = New-Object -ComObject WScript.Shell
-  $sc = $ws.CreateShortcut($lnkPath)
-  if (Test-Path $launcherVbs) {
-    $sc.TargetPath       = Join-Path $env:WINDIR 'System32\wscript.exe'
-    $sc.Arguments        = '//nologo "' + $launcherVbs + '"'
-  } else {
-    $sc.TargetPath       = "$env:ComSpec"
-    $sc.Arguments        = '/d /c call "' + $launcher + '"'
-  }
-  $sc.WorkingDirectory = (Split-Path $launcher)
-  $sc.Description      = 'WorkDaddy – WorkBuddy 增强工具（请以管理员身份运行）'
-  if (Test-Path $logoIco) { $sc.IconLocation = $logoIco + ',0' }   # 用官方 logo，而非 cmd 默认图标
-  $sc.Save()
-  Write-Host ('  桌面快捷方式 : ' + $lnkPath)
-  if (Test-Path $logoIco) { Write-Host ('  图标         : ' + $logoIco) }
-} catch {
-  Write-Host ('  桌面快捷方式创建失败（可忽略，之后可手动创建）: ' + $_.Exception.Message)
+# 5) 启动（daemon + 以 CDP 模式重启 WorkBuddy + 注入）。
+Write-Host '  正在启动 WorkDaddy（如果 WorkBuddy 正在运行，会重启它以开启调试模式）...'
+if (Test-Path -LiteralPath $launcherVbs -PathType Leaf) {
+  $wscript = Join-Path $env:WINDIR 'System32\wscript.exe'
+  Start-Process -FilePath $wscript -ArgumentList ('//B //Nologo "' + $launcherVbs + '"') -WorkingDirectory $targetScripts -WindowStyle Hidden
+} else {
+  Write-Host '  警告：launcher-hidden.vbs 不存在，跳过自动启动（可手动运行 launcher.cmd）'
 }
 
 Write-Host '=============================================================='

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,12 +22,12 @@ CDP_PORT="${WBSWITCH_CDP_PORT:-}"
 
 # 找一个可用的 node（优先 managed，其次 PATH）
 NODE=""
-for c in \
-  "/Users/h/.workbuddy/binaries/node/versions/22.22.2/bin/node" \
-  "/Users/h/.nvm/versions/node/v20.20.2/bin/node" \
-  "$(command -v node 2>/dev/null || true)"; do
-  if [ -n "$c" ] && [ -x "$c" ]; then NODE="$c"; break; fi
+for base in "$HOME/.workbuddy-ai/binaries/node/versions" "$HOME/.workbuddy/binaries/node/versions"; do
+  for c in "$base"/*/bin/node; do
+    if [ -x "$c" ]; then NODE="$c"; break 2; fi
+  done
 done
+if [ -z "$NODE" ]; then NODE="$(command -v node 2>/dev/null || true)"; fi
 if [ -z "$NODE" ]; then
   echo "错误: 未找到 node，请先安装 Node.js"; exit 1
 fi
@@ -98,15 +98,22 @@ echo "   pid: $!"
 
 echo "==> 等待守护进程就绪"
 UI_UP=0
+ACTUAL_UI_PORT="$UI_PORT"
 for i in $(seq 1 10); do
-  if curl -s -m 1 "http://127.0.0.1:${UI_PORT}/api/status" >/dev/null 2>&1; then UI_UP=1; break; fi
+  for candidate in $(seq "$UI_PORT" $((UI_PORT + 7))); do
+    if curl -fsS -m 1 "http://127.0.0.1:${candidate}/healthz" >/dev/null 2>&1; then
+      UI_UP=1
+      ACTUAL_UI_PORT="$candidate"
+      break 2
+    fi
+  done
   sleep 1
 done
 
 echo ""
 echo "=============================================="
 echo "✅ 安装完成！"
-echo "   Web 界面 : http://127.0.0.1:${UI_PORT}"
+echo "   Web 界面 : http://127.0.0.1:${ACTUAL_UI_PORT}"
 echo "   备份目录 : ${DATA_DIR}"
 echo "   CDP 端口 : ${CDP_PORT:-自动探测 (9222/9223/9333)}"
 if [ "$LAUNCHD_OK" = "1" ]; then
@@ -122,5 +129,5 @@ echo "   之后登录/切换账号会实时自动备份，切换后可直接刷�
 echo "=============================================="
 
 # 尝试打开管理界面
-open "http://127.0.0.1:${UI_PORT}" 2>/dev/null || true
+open "http://127.0.0.1:${ACTUAL_UI_PORT}" 2>/dev/null || true
 exit 0

--- a/scripts/launcher-hidden.vbs
+++ b/scripts/launcher-hidden.vbs
@@ -1,5 +1,7 @@
 Option Explicit
 
+If WScript.Arguments.Named.Exists("check") Then WScript.Quit 0
+
 ' Desktop shortcut entry point. wscript.exe has no console window, so running the
 ' shortcut as administrator cannot leave an empty Windows Terminal tab behind.
 Dim shell, fso, launcher, command

--- a/scripts/launcher.cmd
+++ b/scripts/launcher.cmd
@@ -9,12 +9,22 @@ rem 先输出一行 ASCII 状态：管理员启动时 Windows Terminal 可能在
 rem 这行也能区分“正在启动”和“入口没有执行”。
 echo WorkDaddy launcher starting...
 
-rem 定位 node：优先 WorkBuddy 托管运行时（.workbuddy\binaries\node\versions\*），其次 PATH
+rem 定位 node：WorkBuddyAI 托管运行时优先，其次旧 WorkBuddy 与 PATH。
 set "NODE="
-for /d %%d in ("%USERPROFILE%\.workbuddy\binaries\node\versions\*") do (
+for /d %%d in ("%USERPROFILE%\.workbuddy-ai\binaries\node\versions\*") do (
   if exist "%%d\node.exe" set "NODE=%%d\node.exe"
 )
+for /d %%d in ("%USERPROFILE%\.workbuddy\binaries\node\versions\*") do (
+  if not defined NODE if exist "%%d\node.exe" set "NODE=%%d\node.exe"
+)
 if not defined NODE set "NODE=node"
+
+"%NODE%" --experimental-sqlite -e "require('node:sqlite')" >nul 2>&1
+if errorlevel 1 (
+  echo ERROR: the selected Node runtime does not support node:sqlite.
+  echo WorkDaddy requires the managed Node runtime from WorkBuddyAI/WorkBuddy or Node 22+.
+  exit /b 1
+)
 
 if not exist "%~dp0win-launcher.js" (
   echo ERROR: win-launcher.js was not found in the launcher directory.

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -36,23 +36,28 @@ function isLegacyDataDir(dataDir) {
   return !IS_WIN && samePath(dataDir, LEGACY_DATA_DIR);
 }
 
-// macOS: ~/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info
-// Windows: %LOCALAPPDATA%\CodeBuddyExtension\Data\Public\auth\workbuddy-desktop.info（真机已确认）
-const AUTH_FILE =
-  process.env.WBSWITCH_AUTH_FILE ||
-  (IS_WIN
-    ? path.join(
-        process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'),
-        'CodeBuddyExtension',
-        'Data',
-        'Public',
-        'auth',
-        'workbuddy-desktop.info'
-      )
-    : path.join(
-        os.homedir(),
-        'Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info'
-      ));
+// WorkBuddyAI uses a distinct authentication id on Windows. Prefer an existing
+// file so upgrades keep the active product line; only infer from installation
+// paths when neither file has been created yet.
+function defaultAuthFile() {
+  if (!IS_WIN) {
+    return path.join(
+      os.homedir(),
+      'Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info'
+    );
+  }
+  const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+  const authDir = path.join(localAppData, 'CodeBuddyExtension', 'Data', 'Public', 'auth');
+  const ai = path.join(authDir, 'workbuddy-desktop-ai.info');
+  const legacy = path.join(authDir, 'workbuddy-desktop.info');
+  if (fs.existsSync(ai)) return ai;
+  if (fs.existsSync(legacy)) return legacy;
+  return fs.existsSync(path.join(localAppData, 'Programs', 'WorkBuddyAI', 'WorkBuddyAI.exe'))
+    ? ai
+    : legacy;
+}
+
+const AUTH_FILE = process.env.WBSWITCH_AUTH_FILE || defaultAuthFile();
 
 function defaultDataDir() {
   // 旧版 launchd 可能把 WBSWITCH_DATA_DIR 设成 HelloBuddy；新版本始终落到 WorkDaddy，
@@ -70,8 +75,15 @@ function metaFile(dataDir) {
 function logFile(dataDir) {
   return path.join(dataDir, 'daemon.log');
 }
+function validateUid(uid) {
+  const value = String(uid || '');
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+    throw new Error('账号 uid 格式无效');
+  }
+  return value;
+}
 function backupPath(dataDir, uid) {
-  return path.join(accountsDir(dataDir), `${uid}.info`);
+  return path.join(accountsDir(dataDir), `${validateUid(uid)}.info`);
 }
 
 /**
@@ -320,6 +332,7 @@ module.exports = {
   metaFile,
   logFile,
   backupPath,
+  validateUid,
   ensureDirs,
   readAuthFile,
   updateMeta,

--- a/scripts/relaunch-with-cdp.sh
+++ b/scripts/relaunch-with-cdp.sh
@@ -29,8 +29,15 @@ fi
 AUTH_FILE="${WBSWITCH_AUTH_FILE:-$HOME/Library/Application Support/CodeBuddyExtension/Data/Public/auth/workbuddy-desktop.info}"
 APP_BIN="/Applications/WorkBuddy.app/Contents/MacOS/Electron"
 
-# 统一使用的 node 路径（优先系统 PATH，兜底用 managed runtime）
-NODE_BIN="$(command -v node || echo /Users/h/.workbuddy/binaries/node/versions/22.22.2/bin/node)"
+# 统一使用的 node 路径（WorkBuddyAI/WorkBuddy managed runtime 优先）。
+NODE_BIN=""
+for base in "$HOME/.workbuddy-ai/binaries/node/versions" "$HOME/.workbuddy/binaries/node/versions"; do
+  for c in "$base"/*/bin/node; do
+    if [ -x "$c" ]; then NODE_BIN="$c"; break 2; fi
+  done
+done
+if [ -z "$NODE_BIN" ]; then NODE_BIN="$(command -v node 2>/dev/null || true)"; fi
+if [ -z "$NODE_BIN" ]; then echo "错误: 未找到 node"; exit 1; fi
 
 # 清理旧版常驻服务，但保留 HelloBuddy 数据目录；新 daemon 会在启动时迁移旧账号。
 launchctl bootout "gui/$(id -u)" "$LEGACY_PLIST" 2>/dev/null || true
@@ -130,8 +137,16 @@ launch_plugin() {
   fi
 
   # 等待守护进程就绪
+  API_PORT=""
   for i in $(seq 1 10); do
-    curl -s -m 1 "http://127.0.0.1:${PORT:-47832}/api/status" >/dev/null 2>&1 && { echo "==> 守护进程运行中"; break; }
+    local base_api_port="${WBSWITCH_PORT:-47832}"
+    for candidate in $(seq "$base_api_port" $((base_api_port + 7))); do
+      if curl -fsS -m 1 "http://127.0.0.1:${candidate}/healthz" >/dev/null 2>&1; then
+        API_PORT="$candidate"
+        echo "==> 守护进程运行中（端口 ${API_PORT}）"
+        break 2
+      fi
+    done
     sleep 1
   done
 
@@ -169,10 +184,16 @@ launch_plugin() {
   done
 
   if [ "$OK" = "1" ]; then
+    API_PORT="${API_PORT:-${WBSWITCH_PORT:-47832}}"
+    TOKEN_FILE="$DATA_DIR/api-token"
+    if [ -s "$TOKEN_FILE" ]; then
+      curl -fsS -m 3 -X POST -H "X-WorkDaddy-Token: $(cat "$TOKEN_FILE")" \
+        "http://127.0.0.1:${API_PORT}/api/inject" >/dev/null 2>&1 || true
+    fi
     echo ""
     echo "CDP 已开启: http://127.0.0.1:${PORT}"
     echo "   WorkBuddy 启动后右下角会自动出现账号切换组件（约几秒内）。"
-    echo "   若未出现，可手动重新注入: curl -X POST http://127.0.0.1:47832/api/inject"
+    echo "   若未出现，请重新运行本脚本；本地 API 已启用令牌保护。"
   else
     echo ""
     echo "警告：等待 15 秒仍未检测到 WorkBuddy CDP 端口 ${PORT}。"

--- a/scripts/repair-entrypoints.ps1
+++ b/scripts/repair-entrypoints.ps1
@@ -1,0 +1,44 @@
+﻿# Repair the two persistent Windows entry points so both use the console-free
+# VBS launcher. The caller owns the WorkDaddy installation directory.
+param(
+  [string]$AppDir = (Split-Path $PSScriptRoot -Parent)
+)
+
+$ErrorActionPreference = 'Stop'
+$appFull = [IO.Path]::GetFullPath($AppDir).TrimEnd('\')
+$rootFull = [IO.Path]::GetPathRoot($appFull).TrimEnd('\')
+if ([StringComparer]::OrdinalIgnoreCase.Equals($appFull, $rootFull)) {
+  throw '拒绝把驱动器根目录作为 WorkDaddy 安装目录'
+}
+
+$targetScripts = Join-Path $appFull 'scripts'
+$hiddenLauncher = Join-Path $targetScripts 'launcher-hidden.vbs'
+$wscript = Join-Path $env:WINDIR 'System32\wscript.exe'
+if (-not (Test-Path -LiteralPath $hiddenLauncher -PathType Leaf)) { throw 'launcher-hidden.vbs 不存在' }
+if (-not (Test-Path -LiteralPath $wscript -PathType Leaf)) { throw 'wscript.exe 不存在' }
+
+$runKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+$runValue = '"' + $wscript + '" //B //Nologo "' + $hiddenLauncher + '"'
+New-Item -Path $runKey -Force | Out-Null
+Set-ItemProperty -Path $runKey -Name 'WorkDaddy' -Value $runValue
+
+$desktopDir = [Environment]::GetFolderPath('Desktop')
+if (-not $desktopDir) { $desktopDir = Join-Path $env:USERPROFILE 'Desktop' }
+New-Item -ItemType Directory -Force -Path $desktopDir | Out-Null
+$lnkPath = Join-Path $desktopDir 'WorkDaddy.lnk'
+$logoIco = Join-Path $appFull 'WorkDaddy.ico'
+if (-not (Test-Path -LiteralPath $logoIco -PathType Leaf)) {
+  $logoIco = Join-Path $targetScripts 'WorkDaddy.ico'
+}
+
+$ws = New-Object -ComObject WScript.Shell
+$sc = $ws.CreateShortcut($lnkPath)
+$sc.TargetPath = $wscript
+$sc.Arguments = '//B //Nologo "' + $hiddenLauncher + '"'
+$sc.WorkingDirectory = $targetScripts
+$sc.Description = 'WorkDaddy – WorkBuddy 增强工具（静默启动）'
+if (Test-Path -LiteralPath $logoIco -PathType Leaf) { $sc.IconLocation = $logoIco + ',0' }
+$sc.Save()
+
+Write-Host ('  自启入口     : ' + $runValue)
+Write-Host ('  桌面快捷方式 : ' + $lnkPath)

--- a/scripts/verify-win.cmd
+++ b/scripts/verify-win.cmd
@@ -18,7 +18,7 @@ set "FAIL=0"
 rem ---- 1) 关键文件齐全 ----
 echo.
 echo [1/6] 检查关键文件...
-for %%F in (daemon.js lib.js watchdog.js win-launcher.js win-inject-helper.js inject.js theme-patches.js launcher.cmd launcher-hidden.vbs install-win.cmd install-win.ps1 win\setup.sed) do (
+for %%F in (daemon.js lib.js watchdog.js win-launcher.js win-inject-helper.js inject.js theme-patches.js launcher.cmd launcher-hidden.vbs install-win.cmd install-win.ps1 repair-entrypoints.ps1 apply-update.ps1 win\setup.sed) do (
   if not exist "%SCRIPT_DIR%%%F" (
     echo   缺失: %%~F
     set /a FAIL+=1
@@ -40,8 +40,11 @@ rem ---- 2) node 运行时可达性 ----
 echo.
 echo [2/6] 检查 node 运行时...
 set "NODE="
-for /d %%d in ("%USERPROFILE%\.workbuddy\binaries\node\versions\*") do (
+for /d %%d in ("%USERPROFILE%\.workbuddy-ai\binaries\node\versions\*") do (
   if exist "%%d\node.exe" set "NODE=%%d\node.exe"
+)
+for /d %%d in ("%USERPROFILE%\.workbuddy\binaries\node\versions\*") do (
+  if not defined NODE if exist "%%d\node.exe" set "NODE=%%d\node.exe"
 )
 if not defined NODE set "NODE=node"
 "%NODE%" --version >nul 2>&1
@@ -51,11 +54,16 @@ if errorlevel 1 (
 ) else (
   echo   可用: %NODE%
 )
+"%NODE%" --experimental-sqlite -e "require('node:sqlite')" >nul 2>&1
+if errorlevel 1 (
+  echo   错误: 当前 node 不支持 node:sqlite（Windows 会话管理不可用）
+  set /a FAIL+=1
+)
 
 rem ---- 3) 脚本语法静态检查（node --check，不执行）----
 echo.
 echo [3/6] 校验 JS 语法...
-for %%F in (daemon.js lib.js watchdog.js win-launcher.js inject.js theme-patches.js) do (
+for %%F in (daemon.js lib.js watchdog.js win-launcher.js win-inject-helper.js inject.js theme-patches.js) do (
   "%NODE%" --check "%SCRIPT_DIR%%%F" >nul 2>&1
   if errorlevel 1 (
     echo   语法错误: %%~F
@@ -63,17 +71,16 @@ for %%F in (daemon.js lib.js watchdog.js win-launcher.js inject.js theme-patches
   )
 )
 echo   JS 语法检查完成
+cscript //B //Nologo "%SCRIPT_DIR%launcher-hidden.vbs" /check >nul 2>&1
+if errorlevel 1 (
+  echo   语法错误: launcher-hidden.vbs
+  set /a FAIL+=1
+)
 
 rem ---- 4) PS1 合法性（PowerShell 解析但不执行）----
 echo.
 echo [4/6] 校验 PS1 脚本语法...
-for %%F in (install-win.ps1) do (
-  powershell -NoProfile -ExecutionPolicy Bypass -Command "$e=$null; [void][System.Management.Automation.Language.Parser]::ParseFile('%SCRIPT_DIR%%%F',[ref]$null,[ref]$e); if($e){Write-Host ('  语法错误: ' + $e.Message); exit 1} else {Write-Host ('  OK: ' + '%%~nF')}; exit 0" >nul 2>&1
-  if errorlevel 1 (
-    echo   语法错误: %%~F
-    set /a FAIL+=1
-  )
-)
+for %%F in (install-win.ps1 repair-entrypoints.ps1 apply-update.ps1 uninstall-win.ps1) do call :CheckPs1 "%SCRIPT_DIR%%%F" "%%~F"
 
 rem ---- 5) 自启注册表与安装目录回写测试（读态 + 安装目录可写性探测）----
 echo.
@@ -109,4 +116,16 @@ if "%FAIL%"=="0" (
   echo  发现 %FAIL% 处问题，请在下方对照修正后再分发。
 )
 echo ============================================================
-pause
+if /I not "%~1"=="--ci" pause
+exit /b %FAIL%
+
+:CheckPs1
+set "PS1_CHECK_PATH=%~1"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$tokens=$null; $errors=$null; [void][System.Management.Automation.Language.Parser]::ParseFile($env:PS1_CHECK_PATH,[ref]$tokens,[ref]$errors); if($errors.Count -gt 0){exit 1}; exit 0" >nul 2>&1
+if errorlevel 1 (
+  echo   语法错误: %~2
+  set /a FAIL+=1
+) else (
+  echo   OK: %~2
+)
+exit /b 0

--- a/scripts/win-launcher.js
+++ b/scripts/win-launcher.js
@@ -23,10 +23,13 @@ const SCRIPTS_DIR = __dirname;
 const DATA_DIR =
   process.env.WBSWITCH_DATA_DIR ||
   path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'WorkDaddy');
-const UI_PORT = parseInt(process.env.WBSWITCH_PORT || '47832', 10);
+const UI_PORT_BASE = parseInt(process.env.WBSWITCH_PORT || '47832', 10);
+let actualUiPort = UI_PORT_BASE;
 const cliCdpPort = process.argv.find((arg) => /^--cdp-port=\d+$/i.test(arg));
-const CDP_PORT = parseInt(process.env.WBSWITCH_CDP_PORT || (cliCdpPort ? cliCdpPort.split('=')[1] : '') || '9222', 10);
+const CONFIGURED_CDP_PORT = parseInt(process.env.WBSWITCH_CDP_PORT || (cliCdpPort ? cliCdpPort.split('=')[1] : '') || '9222', 10);
+let CDP_PORT = CONFIGURED_CDP_PORT;
 const ELEVATED_HELPER_MODE = process.argv.includes('--inject-helper');
+const LAUNCHER_LOCK_FILE = path.join(DATA_DIR, 'launcher.lock');
 
 function log(...args) {
   const line = `[launcher] ${new Date().toISOString()} ${args.join(' ')}\n`;
@@ -36,6 +39,57 @@ function log(...args) {
 
 // ---------- 小工具 ----------
 function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function processCommandLine(pid) {
+  if (!pid || pid === process.pid) return false;
+  try {
+    const r = spawnSync('powershell', [
+      '-NoProfile', '-Command',
+      `(Get-CimInstance Win32_Process -Filter "ProcessId=${Number(pid)}" -ErrorAction SilentlyContinue).CommandLine`,
+    ], {
+      encoding: 'utf8', timeout: 5000, windowsHide: true,
+    });
+    return r.status === 0 ? String(r.stdout || '').trim() : '';
+  } catch (_) { return ''; }
+}
+
+function processOwnsScript(pid, scriptPath) {
+  const commandLine = processCommandLine(pid);
+  return !!commandLine && commandLine.toLowerCase().includes(path.resolve(scriptPath).toLowerCase());
+}
+
+async function acquireLauncherLock(waitMs) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  const deadline = Date.now() + Math.max(0, waitMs || 0);
+  do {
+    try {
+      fs.writeFileSync(LAUNCHER_LOCK_FILE, JSON.stringify({
+        pid: process.pid,
+        role: ELEVATED_HELPER_MODE ? 'elevated-helper' : 'launcher',
+        startedAt: new Date().toISOString(),
+      }), { flag: 'wx', mode: 0o600 });
+      return true;
+    } catch (e) {
+      if (!e || e.code !== 'EEXIST') throw e;
+      let ownerPid = 0;
+      try { ownerPid = Number(JSON.parse(fs.readFileSync(LAUNCHER_LOCK_FILE, 'utf8')).pid); } catch (_) {}
+      if (!processOwnsScript(ownerPid, path.join(SCRIPTS_DIR, 'win-launcher.js'))) {
+        try { fs.unlinkSync(LAUNCHER_LOCK_FILE); } catch (_) {}
+        continue;
+      }
+      if (Date.now() >= deadline) return false;
+      await sleep(200);
+    }
+  } while (Date.now() <= deadline);
+  return false;
+}
+
+function releaseLauncherLock() {
+  try {
+    const owner = JSON.parse(fs.readFileSync(LAUNCHER_LOCK_FILE, 'utf8'));
+    if (Number(owner.pid) === process.pid) fs.unlinkSync(LAUNCHER_LOCK_FILE);
+  } catch (_) {}
+}
 
 // 当前进程是否为管理员（Windows）
 function isElevated() {
@@ -91,7 +145,11 @@ function portOpen(port) {
 
 function httpGet(port, p) {
   return new Promise((resolve) => {
-    const req = http.get({ host: '127.0.0.1', port, path: p, timeout: 1500 }, (res) => {
+    const token = readApiToken();
+    const req = http.get({
+      host: '127.0.0.1', port, path: p, timeout: 1500,
+      headers: token ? { 'X-WorkDaddy-Token': token } : {},
+    }, (res) => {
       let body = '';
       res.on('data', (c) => (body += c));
       res.on('end', () => resolve({ status: res.statusCode, body }));
@@ -103,7 +161,11 @@ function httpGet(port, p) {
 
 function httpPost(port, p) {
   return new Promise((resolve) => {
-    const req = http.request({ host: '127.0.0.1', port, path: p, method: 'POST', timeout: 1500 }, (res) => {
+    const token = readApiToken();
+    const req = http.request({
+      host: '127.0.0.1', port, path: p, method: 'POST', timeout: 1500,
+      headers: token ? { 'X-WorkDaddy-Token': token } : {},
+    }, (res) => {
       res.resume();
       res.on('end', () => resolve({ status: res.statusCode }));
     });
@@ -113,13 +175,30 @@ function httpPost(port, p) {
   });
 }
 
-async function isWorkBuddyCdp() {
-  const version = await httpGet(CDP_PORT, '/json/version');
+function readApiToken() {
+  try { return fs.readFileSync(path.join(DATA_DIR, 'api-token'), 'utf8').trim(); } catch (_) { return ''; }
+}
+
+async function isWorkBuddyCdpAt(port) {
+  const version = await httpGet(port, '/json/version');
   if (!version || version.status !== 200) return false;
   try {
     const info = JSON.parse(version.body || '{}');
-    return /workbuddy|codebuddy/i.test([info.Browser, info['User-Agent']].filter(Boolean).join(' '));
+    return /workbuddyai|workbuddy|codebuddy/i.test([info.Browser, info['User-Agent']].filter(Boolean).join(' '));
   } catch (_) { return false; }
+}
+
+async function isWorkBuddyCdp() { return isWorkBuddyCdpAt(CDP_PORT); }
+
+async function selectCdpPort() {
+  const candidates = [...new Set([CONFIGURED_CDP_PORT, 9222, 9223, 9333])];
+  for (const port of candidates) {
+    if (await isWorkBuddyCdpAt(port)) return { port, existing: true };
+  }
+  for (const port of candidates) {
+    if (!(await portOpen(port))) return { port, existing: false };
+  }
+  throw new Error('没有可用的 WorkBuddy CDP 端口（已检查 ' + candidates.join(', ') + '）');
 }
 
 function psOut(cmd) {
@@ -138,16 +217,18 @@ function readDaemonVersion() {
   } catch (_) { return ''; }
 }
 
-// ---------- 定位 node（托管优先：.workbuddy\binaries\node\versions\<v>\node.exe，其次 PATH） ----------
+// ---------- 定位 node（WorkBuddyAI/legacy 托管运行时优先，其次 PATH） ----------
 function findNode() {
-  const base = path.join(os.homedir(), '.workbuddy', 'binaries', 'node', 'versions');
   let verDirs = [];
-  try {
-    verDirs = fs.readdirSync(base)
-      .map((d) => path.join(base, d, 'node.exe'))
-      .filter((p) => fs.existsSync(p))
-      .sort();
-  } catch (_) {}
+  for (const homeName of ['.workbuddy-ai', '.workbuddy']) {
+    const base = path.join(os.homedir(), homeName, 'binaries', 'node', 'versions');
+    try {
+      verDirs.push(...fs.readdirSync(base)
+        .map((d) => path.join(base, d, 'node.exe'))
+        .filter((p) => fs.existsSync(p)));
+    } catch (_) {}
+  }
+  verDirs.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   if (verDirs.length) return verDirs[verDirs.length - 1];
   try {
     const r = spawnSync('node', ['-v'], { encoding: 'utf8', timeout: 3000, windowsHide: true });
@@ -156,7 +237,7 @@ function findNode() {
   return null;
 }
 
-// ---------- 定位 WorkBuddy.exe（环境变量 > 运行进程 > 注册表 > 常见路径） ----------
+// ---------- 定位 WorkBuddy/WorkBuddyAI（环境变量 > 运行进程 > 注册表 > 常见路径） ----------
 let wbBinaryCache = null;
 function findWorkBuddy() {
   if (wbBinaryCache) return wbBinaryCache;
@@ -164,16 +245,19 @@ function findWorkBuddy() {
   const envBin = tryFile(process.env.WBSWITCH_WORKBUDDY_BIN);
   if (envBin) return (wbBinaryCache = envBin);
   try {
-    const p = psOut('Get-Process WorkBuddy -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Path').split(/\r?\n/).filter(Boolean).pop();
+    const p = psOut('Get-Process WorkBuddyAI,WorkBuddy -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Path').split(/\r?\n/).filter(Boolean).pop();
     const hit = tryFile(p);
     if (hit) return (wbBinaryCache = hit);
   } catch (_) {}
   try {
-    const p = psOut("$k=@('HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'); Get-ItemProperty $k -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -match 'WorkBuddy|CodeBuddy' } | Select-Object -First 1 DisplayIcon,InstallLocation | ForEach-Object { if($_.DisplayIcon){ ($_.DisplayIcon -replace ',.*$','').Trim() } elseif($_.InstallLocation){ Join-Path $_.InstallLocation 'WorkBuddy.exe' } }").split(/\r?\n/).filter(Boolean).pop();
+    const p = psOut("$k=@('HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*','HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'); Get-ItemProperty $k -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -match 'WorkBuddy|CodeBuddy' } | Select-Object -First 1 DisplayIcon,InstallLocation | ForEach-Object { if($_.DisplayIcon){ ($_.DisplayIcon -replace ',.*$','').Trim() } elseif($_.InstallLocation){ $ai=Join-Path $_.InstallLocation 'WorkBuddyAI.exe'; $legacy=Join-Path $_.InstallLocation 'WorkBuddy.exe'; if(Test-Path $ai){$ai}else{$legacy} } }").split(/\r?\n/).filter(Boolean).pop();
     const hit = tryFile(p);
     if (hit) return (wbBinaryCache = hit);
   } catch (_) {}
   for (const c of [
+    path.join(process.env.LOCALAPPDATA || '', 'Programs', 'WorkBuddyAI', 'WorkBuddyAI.exe'),
+    path.join(process.env.ProgramFiles || '', 'WorkBuddyAI', 'WorkBuddyAI.exe'),
+    path.join(process.env['ProgramFiles(x86)'] || '', 'WorkBuddyAI', 'WorkBuddyAI.exe'),
     path.join(process.env.LOCALAPPDATA || '', 'Programs', 'WorkBuddy', 'WorkBuddy.exe'),
     path.join(process.env.ProgramFiles || '', 'WorkBuddy', 'WorkBuddy.exe'),
     path.join(process.env['ProgramFiles(x86)'] || '', 'WorkBuddy', 'WorkBuddy.exe'),
@@ -189,35 +273,60 @@ function findWorkBuddy() {
 function watchdogAlive() {
   try {
     const pid = parseInt(fs.readFileSync(path.join(DATA_DIR, 'watchdog.pid'), 'utf8').trim(), 10);
-    if (!pid) return false;
-    const r = spawnSync('tasklist', ['/FI', 'PID eq ' + pid, '/FO', 'CSV', '/NH'], { encoding: 'utf8', timeout: 5000, windowsHide: true });
-    return r.status === 0 && /node/i.test(r.stdout);
+    return !!pid && processOwnsScript(pid, path.join(SCRIPTS_DIR, 'watchdog.js'));
   } catch (_) { return false; }
 }
 
-function daemonRunning() {
-  return portOpen(UI_PORT);
+async function findDaemonPort() {
+  for (let port = UI_PORT_BASE; port < UI_PORT_BASE + 8; port++) {
+    const health = await httpGet(port, '/healthz');
+    if (health && health.status === 200) {
+      try {
+        const parsed = JSON.parse(health.body);
+        if (parsed && parsed.ok === true && parsed.service === 'workdaddy') {
+          actualUiPort = port;
+          return { port, health: parsed };
+        }
+      } catch (_) {}
+    }
+    // 1.0.5 did not expose /healthz. Recognize its richer status payload only
+    // for the upgrade path, then restart it into the authenticated API.
+    const legacyStatus = await httpGet(port, '/api/status');
+    if (legacyStatus && legacyStatus.status === 200) {
+      try {
+        const parsed = JSON.parse(legacyStatus.body);
+        if (parsed && parsed.ok === true && typeof parsed.version === 'string' && parsed.cdp && parsed.dataDir) {
+          actualUiPort = port;
+          return { port, health: { ...parsed, service: 'workdaddy' } };
+        }
+      } catch (_) {}
+    }
+  }
+  return null;
 }
 
-async function ensureDaemon(nodeBin) {
+async function daemonRunning() {
+  return !!(await findDaemonPort());
+}
+
+async function ensureDaemon(nodeBin, forceRestart) {
   fs.mkdirSync(path.join(DATA_DIR, 'accounts'), { recursive: true });
   // 已有 daemon：检查版本一致性（旧版本代码继续注入会出兼容问题）
-  const st = await httpGet(UI_PORT, '/api/status');
-  if (st && st.status === 200) {
-    let runningVer = '';
-    try { runningVer = (JSON.parse(st.body).version || ''); } catch (_) {}
+  const found = await findDaemonPort();
+  if (found) {
+    const runningVer = found.health.version || '';
     const want = readDaemonVersion();
-    if (runningVer === want) {
-      log('daemon 已在运行且版本一致 (' + runningVer + ')，跳过启动');
+    if (!forceRestart && runningVer === want) {
+      log('daemon 已在运行且版本一致 (' + runningVer + ', port=' + actualUiPort + ')，跳过启动');
       return true;
     }
-    log('检测到旧版 daemon (' + runningVer + ' != ' + want + ')，强制重启');
-    stopDaemonByPort();
+    log('daemon 需要重启 (' + runningVer + ' -> ' + want + ', cdp=' + CDP_PORT + ')');
+    stopDaemonByPort(actualUiPort);
   } else if (watchdogAlive()) {
     log('watchdog 在运行但 daemon 未就绪，等待其拉起...');
     for (let i = 0; i < 20; i++) {
       await sleep(500);
-      if (daemonRunning()) { log('daemon 已就绪'); return true; }
+      if (await daemonRunning()) { log('daemon 已就绪 (port=' + actualUiPort + ')'); return true; }
     }
     log('等待超时，主动拉起 watchdog');
   }
@@ -229,22 +338,24 @@ async function ensureDaemon(nodeBin) {
   }
   for (let i = 0; i < 30; i++) {
     await sleep(400);
-    if (daemonRunning()) { log('daemon 已就绪'); return true; }
+    if (await daemonRunning()) { log('daemon 已就绪 (port=' + actualUiPort + ')'); return true; }
   }
   log('等待 daemon 就绪超时');
-  return daemonRunning();
+  return await daemonRunning();
 }
 
-function stopDaemonByPort() {
+function stopDaemonByPort(port = actualUiPort) {
   // 杀 watchdog（会连带杀 daemon）→ 兜底按端口杀
   try {
     const pid = parseInt(fs.readFileSync(path.join(DATA_DIR, 'watchdog.pid'), 'utf8').trim(), 10);
-    if (pid) spawnSync('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore', windowsHide: true });
+    if (pid && processOwnsScript(pid, path.join(SCRIPTS_DIR, 'watchdog.js'))) {
+      spawnSync('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore', windowsHide: true });
+    }
     try { fs.unlinkSync(path.join(DATA_DIR, 'watchdog.pid')); } catch (_) {}
   } catch (_) {}
   // 兜底：杀监听 UI 端口的进程
   const out = spawnSync('netstat', ['-ano'], { encoding: 'utf8', timeout: 8000, windowsHide: true }).stdout || '';
-  const lines = out.split(/\r?\n/).filter((l) => l.includes(':' + UI_PORT) && /LISTENING/i.test(l));
+  const lines = out.split(/\r?\n/).filter((l) => l.includes(':' + port) && /LISTENING/i.test(l));
   const pids = new Set();
   for (const l of lines) {
     const m = l.trim().split(/\s+/);
@@ -252,20 +363,25 @@ function stopDaemonByPort() {
     if (pid && /^\d+$/.test(pid)) pids.add(pid);
   }
   for (const pid of pids) {
-    spawnSync('taskkill', ['/F', '/T', '/PID', pid], { stdio: 'ignore', windowsHide: true });
+    if (processOwnsScript(Number(pid), path.join(SCRIPTS_DIR, 'daemon.js'))) {
+      spawnSync('taskkill', ['/F', '/T', '/PID', pid], { stdio: 'ignore', windowsHide: true });
+    } else {
+      log('拒绝结束端口 ' + port + ' 上的非 WorkDaddy 进程 pid=' + pid);
+    }
   }
   return pids.size > 0;
 }
 
 // ---------- 2/3. WorkBuddy CDP 处理 ----------
-function workBuddyRunning() {
+function workBuddyRunning(wb) {
+  const imageName = path.basename(wb || '') || 'WorkBuddy.exe';
   try {
     const r = spawnSync(
       'tasklist',
-      ['/FI', 'IMAGENAME eq WorkBuddy.exe', '/FO', 'CSV', '/NH'],
+      ['/FI', 'IMAGENAME eq ' + imageName, '/FO', 'CSV', '/NH'],
       { encoding: 'utf8', timeout: 5000, windowsHide: true }
     );
-    return r.status === 0 && /"WorkBuddy\.exe"/i.test(r.stdout || '');
+    return r.status === 0 && (r.stdout || '').toLowerCase().includes('"' + imageName.toLowerCase() + '"');
   } catch (_) {
     return true;
   }
@@ -288,21 +404,22 @@ function runTaskkill(args) {
   });
 }
 
-async function waitForWorkBuddyExit(timeoutMs) {
+async function waitForWorkBuddyExit(wb, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (!workBuddyRunning()) return true;
+    if (!workBuddyRunning(wb)) return true;
     await sleep(200);
   }
-  return !workBuddyRunning();
+  return !workBuddyRunning(wb);
 }
 
-async function quitWorkBuddy() {
-  if (!workBuddyRunning()) return true;
-  await runTaskkill(['/IM', 'WorkBuddy.exe']);
-  if (await waitForWorkBuddyExit(1800)) return true;
-  await runTaskkill(['/F', '/T', '/IM', 'WorkBuddy.exe']);
-  if (await waitForWorkBuddyExit(4000)) return true;
+async function quitWorkBuddy(wb) {
+  const imageName = path.basename(wb || '') || 'WorkBuddy.exe';
+  if (!workBuddyRunning(wb)) return true;
+  await runTaskkill(['/IM', imageName]);
+  if (await waitForWorkBuddyExit(wb, 1800)) return true;
+  await runTaskkill(['/F', '/T', '/IM', imageName]);
+  if (await waitForWorkBuddyExit(wb, 4000)) return true;
   throw new Error('无法确认 WorkBuddy 已退出');
 }
 
@@ -354,8 +471,25 @@ function launchWorkBuddy(wb) {
 }
 
 async function injectNow() {
-  // daemon 的 /api/inject 是 POST
-  try { await httpPost(UI_PORT, '/api/inject'); } catch (_) {}
+  const result = await httpPost(actualUiPort, '/api/inject');
+  return !!(result && result.status >= 200 && result.status < 300);
+}
+
+async function waitForInjection() {
+  for (let i = 0; i < 12; i++) {
+    if (await injectNow()) return true;
+    await sleep(500);
+  }
+  return false;
+}
+
+function handoffToElevatedHelper() {
+  if (!spawnElevatedHelper()) return false;
+  // The elevated launcher waits for this owner to release the lock. Releasing
+  // only after Start-Process succeeds closes the old UAC/lock race.
+  releaseLauncherLock();
+  log('已把启动流程交给管理员助手');
+  return true;
 }
 
 // ---------- main ----------
@@ -364,12 +498,23 @@ async function injectNow() {
   // 探测耗时让 Windows Terminal 看起来像“空白无响应”；同一行也会落到 launcher.log。
   try { fs.mkdirSync(DATA_DIR, { recursive: true }); } catch (_) {}
   log('启动入口: scripts=' + SCRIPTS_DIR + ' data=' + DATA_DIR + ' pid=' + process.pid);
+  if (!(await acquireLauncherLock(ELEVATED_HELPER_MODE ? 10000 : 0))) {
+    log('已有 launcher 实例在运行，本次启动跳过');
+    process.exit(0);
+  }
+  process.on('exit', releaseLauncherLock);
+
   const nodeBin = findNode();
   if (!nodeBin) {
-    log('未找到 Node.js（需 .workbuddy\\binaries 托管 node 或 PATH 中的 node）');
+    log('未找到 Node.js（需 .workbuddy-ai/.workbuddy 托管 node 或 PATH 中的 node）');
     console.error('错误：未找到 Node.js。请先安装 Node.js 或安装 WorkBuddy（自带托管 node）。');
     process.exit(1);
   }
+
+  const cdpSelection = await selectCdpPort();
+  CDP_PORT = cdpSelection.port;
+  process.env.WBSWITCH_CDP_PORT = String(CDP_PORT);
+  log('CDP 端口: ' + CDP_PORT + (cdpSelection.existing ? '（已有 WorkBuddy）' : '（可用）'));
 
   // 提权助手接管时，先停掉普通权限启动的 watchdog/daemon，避免两个权限级别的
   // daemon 同时占用端口；WorkBuddy GUI 后续仍由 ShellExecute 以用户权限启动。
@@ -378,11 +523,18 @@ async function injectNow() {
     stopDaemonByPort();
     await sleep(800);
   }
-  await ensureDaemon(nodeBin);
+  const daemonReady = await ensureDaemon(nodeBin, CDP_PORT !== CONFIGURED_CDP_PORT);
+  if (!daemonReady) {
+    console.error('WorkDaddy daemon 启动失败。日志：' + path.join(DATA_DIR, 'launcher.log'));
+    process.exit(5);
+  }
 
   // 已在 CDP 模式 → 幂等注入
   if (await isWorkBuddyCdp()) {
-    await injectNow();
+    if (!(await waitForInjection())) {
+      log('WorkBuddy 已在调试模式，但 /api/inject 调用失败');
+      process.exit(6);
+    }
     log('WorkBuddy 已在调试模式（端口 ' + CDP_PORT + '），组件已注入');
     console.log('WorkDaddy：WorkBuddy 已在调试模式，组件已注入 ✓');
     process.exit(0);
@@ -391,29 +543,21 @@ async function injectNow() {
   // 未开 CDP → 需要重启 WorkBuddy 带调试端口
   const wb = findWorkBuddy();
   if (!wb) {
-    console.error('未找到 WorkBuddy.exe。可用环境变量 WBSWITCH_WORKBUDDY_BIN 指定完整路径。');
-    log('未找到 WorkBuddy.exe');
+    console.error('未找到 WorkBuddy/WorkBuddyAI 可执行文件。可用环境变量 WBSWITCH_WORKBUDDY_BIN 指定完整路径。');
+    log('未找到 WorkBuddy/WorkBuddyAI 可执行文件');
     process.exit(2);
-  }
-
-  // WorkBuddy 常装在 C:\Program Files（受保护特权目录），结束已提升的旧进程可能需要管理员权限。
-  // 若当前非管理员：派发提权助手（触发一次 UAC）后立即退出，由助手完成重启+注入，
-  // 避免普通双击时卡在黑屏空转等 20 秒。
-  if (!isElevated()) {
-    log('非管理员权限：派发提权助手重启 WorkBuddy（唤醒 UAC）');
-    console.log('需要管理员权限以重启 WorkBuddy 进入调试模式，正在请求授权...');
-    if (spawnElevatedHelper()) {
-      console.log('已发起提权请求，点击 UAC「是」后将自动完成重启与注入。');
-      process.exit(0);
-    }
-    // 派发失败则仍退回当前进程尝试（容错）
-    log('提权派发失败，退回当前进程直接重启');
   }
 
   log('重启 WorkBuddy（带 --remote-debugging-port=' + CDP_PORT + '，GUI 使用当前用户权限）: ' + wb);
   console.log('正在以调试模式重启 WorkBuddy（约几秒）...');
 
-  await quitWorkBuddy();
+  try {
+    await quitWorkBuddy(wb);
+  } catch (e) {
+    log('普通权限退出 WorkBuddy 失败: ' + e.message);
+    if (!isElevated() && !ELEVATED_HELPER_MODE && handoffToElevatedHelper()) process.exit(0);
+    throw e;
+  }
   await sleep(500);
   launchWorkBuddy(wb);
 
@@ -424,14 +568,19 @@ async function injectNow() {
   }
   if (ok) {
     await sleep(1500);
-    await injectNow();
+    if (!(await waitForInjection())) {
+      log('WorkBuddy CDP 已启动，但 /api/inject 调用失败');
+      process.exit(6);
+    }
     log('WorkBuddy 已启动（调试模式），组件已注入');
     console.log('WorkDaddy：WorkBuddy 已启动（调试模式），组件已注入 ✓');
-  } else {
-    log('等待 20 秒未检测到调试端口 ' + CDP_PORT);
-    console.log('等待超时：未检测到调试端口 ' + CDP_PORT + '。可手动执行：cd /d ' + path.dirname(wb) + ' && "' + wb + '" --remote-debugging-port=' + CDP_PORT);
+    process.exit(0);
   }
-  process.exit(ok ? 0 : 3);
+
+  log('等待 20 秒未检测到 WorkBuddy CDP 端口 ' + CDP_PORT);
+  if (!isElevated() && !ELEVATED_HELPER_MODE && handoffToElevatedHelper()) process.exit(0);
+  console.log('等待超时：未检测到 WorkBuddy CDP 端口 ' + CDP_PORT + '。可手动执行：cd /d ' + path.dirname(wb) + ' && "' + wb + '" --remote-debugging-port=' + CDP_PORT);
+  process.exit(3);
 })().catch((e) => {
   log('launcher 异常: ' + (e && e.stack || e));
   console.error('WorkDaddy 启动异常: ' + (e && e.message || e));


### PR DESCRIPTION
## 背景

Windows 旧实现仍假设 `WorkBuddy.exe`、`workbuddy-desktop.info` 和 `.workbuddy`。WorkBuddyAI 5.3.x 已使用 `WorkBuddyAI.exe`、`workbuddy-desktop-ai.info` 与 `.workbuddy-ai`，同时旧启动链存在 UAC/单实例锁竞态、黑框入口、本地 API 无鉴权和更新包校验不足等问题。

Refs #1

## 本次修改

### WorkBuddyAI 与 Windows 启动

- 同时识别 WorkBuddyAI/WorkBuddy 的进程、安装路径、认证文件和数据目录
- 按 CDP Browser/User-Agent 验证端口身份，避免连接到无关 Chromium 调试端口
- 修复普通 launcher 与提权 helper 的锁交接竞态；仅在普通权限真实失败后请求 UAC
- 桌面快捷方式、HKCU Run、安装和更新重启统一使用无控制台 VBS 入口
- 停止 watchdog、daemon 或 launcher 前校验 PID/命令行确实属于当前 WorkDaddy 安装
- 版本提升到 1.0.6

### 本地 API 与输入边界

- daemon 首次启动生成 64 位十六进制随机 Token；所有 `/api/*` 与 DevTools WebSocket proxy 均校验 Token
- 注入组件、macOS 重启脚本和 Windows launcher 全部同步携带 Token
- UID 使用固定字符白名单，阻断备份路径穿越
- JSON 请求体限制为 16 MiB；坏 JSON 返回 400，超限返回 413

### 安全更新与回滚

- 更新摘要按具体 ZIP/DMG 资产名称绑定，优先使用 GitHub asset digest
- Release 未提供 SHA-256 时拒绝安装
- Windows 更新先在独立目录解压并验证完整包结构，再停止旧进程和替换安装目录
- 新版本未通过 `/healthz` 时恢复 `.old` 目录并重新启动旧版本
- Release workflow 写入带资产文件名的 SHA-256 说明

### Windows Release / CI

- Shell 强制 LF、CMD 保留 CRLF，并在 CI 检查纯净换行
- `build-win-zip.sh` 只在 staging 中补齐依赖与资源，不污染仓库工作树
- 始终生成标准 ZIP；保留旧 updater 需要的根目录 launcher shim
- PR、手动触发和两种 tag 风格均运行 Windows 验证
- CI 验证最终 ZIP、包内脚本、API 鉴权/请求边界以及无效更新包保护
- 当前以已验证的 win64 ZIP 为发布产物，不调用旧的 IExpress Setup 流程

## 已执行验证

- Node `--check`：daemon、inject、lib、win-launcher
- Windows PowerShell 5 Parser：install、repair、apply-update、uninstall
- `bash -n`：Windows 打包、macOS install/relaunch
- Workflow YAML 与 `git diff --check`
- API 契约：health 200、无/错 Token 403、正确 Token 200、坏 JSON 400、超大请求 413
- 无效 ZIP 更新防护：在临时安装目录验证拒绝更新且原安装标记保持不变
- 实际构建并在带空格路径解压 `WorkDaddy-1.0.6-win64.zip`，包内 `verify-win.cmd --ci` 通过
- 本机只读确认 WorkBuddyAI 路径与 `workbuddy-desktop-ai.info` 文件名

## 尚未覆盖

- 本次没有覆盖安装当前用户的 WorkBuddyAI，也没有重新执行机器人按钮、UAC 弹窗和开机自启的真实桌面验收
- 仓库未跟踪 `WorkDaddy.app` 内置壁纸和 `release/WorkDaddy.ico`；干净 checkout 生成的 ZIP 会使用默认图标且不含官方壁纸

## 远端 CI

- ✅ Windows release workflow 全部通过：[运行记录](https://github.com/iiijiashu/WorkDaddy/actions/runs/32402808560)
