### PR TITLE
fix(ci): propagate Windows package verification failures

### DIFF
--- a/scripts/verify-win.cmd
+++ b/scripts/verify-win.cmd
@@ -5,6 +5,8 @@ rem  作用：验证 Setup.exe / zip 解出的 scripts 是否「完整、可装�
 rem  不修改任何系统状态，纯只读检查，可放心重复运行。
 rem ============================================================
 setlocal
+for /f "tokens=2 delims=:" %%C in ('chcp') do set "ORIGINAL_CODE_PAGE=%%C"
+set "ORIGINAL_CODE_PAGE=%ORIGINAL_CODE_PAGE: =%"
 chcp 65001 >nul
 cd /d "%~dp0"
 set "SCRIPT_DIR=%~dp0"
@@ -104,9 +106,13 @@ if exist "%USERPROFILE%\Desktop\WorkDaddy.lnk" (
 echo.
 echo ============================================================
 if "%FAIL%"=="0" (
+  set "VERIFY_EXIT=0"
   echo  自检通过：本包可用于 Windows 安装。
 ) else (
+  set "VERIFY_EXIT=1"
   echo  发现 %FAIL% 处问题，请在下方对照修正后再分发。
 )
 echo ============================================================
-pause
+if not defined CI pause
+if defined ORIGINAL_CODE_PAGE chcp %ORIGINAL_CODE_PAGE% >nul
+exit /b %VERIFY_EXIT%

--- a/test/verify-win-exit.test.js
+++ b/test/verify-win-exit.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const repoRoot = path.join(__dirname, '..');
+const verifyScript = path.join(repoRoot, 'scripts', 'verify-win.cmd');
+const source = fs.readFileSync(verifyScript, 'utf8');
+
+function isolatedEnv(dir) {
+  const profile = path.join(dir, 'profile');
+  const localAppData = path.join(profile, 'AppData', 'Local');
+  const appData = path.join(profile, 'AppData', 'Roaming');
+  fs.mkdirSync(localAppData, { recursive: true });
+  fs.mkdirSync(appData, { recursive: true });
+  return {
+    ...process.env,
+    CI: '1',
+    USERPROFILE: profile,
+    LOCALAPPDATA: localAppData,
+    APPDATA: appData,
+  };
+}
+
+test('Windows verifier returns a stable success or failure exit code', () => {
+  assert.match(source, /set "VERIFY_EXIT=0"/);
+  assert.match(source, /set "VERIFY_EXIT=1"/);
+  assert.match(source, /if not defined CI pause/i);
+  assert.match(source, /set "ORIGINAL_CODE_PAGE=/);
+  assert.match(source, /chcp %ORIGINAL_CODE_PAGE%/i);
+  assert.match(source, /exit \/b %VERIFY_EXIT%/i);
+});
+
+test('Windows verifier reports missing package files as a failing process', { skip: process.platform !== 'win32' }, () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workdaddy-verify-win-'));
+  const isolatedScript = path.join(dir, 'verify-win.cmd');
+  try {
+    fs.copyFileSync(verifyScript, isolatedScript);
+    const result = spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/c', 'call', isolatedScript], {
+      encoding: 'utf8',
+      env: isolatedEnv(dir),
+      timeout: 10000,
+      windowsHide: true,
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 1, result.stdout + result.stderr);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('Windows verifier returns success for a complete source package', { skip: process.platform !== 'win32' }, () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workdaddy-verify-win-complete-'));
+  const scriptsDir = path.join(dir, 'scripts');
+  const required = [
+    'daemon.js', 'session-db.js', 'lib.js', 'watchdog.js', 'win-launcher.js',
+    'windows-process-boundary.js', 'windows-process-boundary.ps1', 'inject.js',
+    'theme-patches.js', 'launcher.cmd', 'launcher-hidden.vbs', 'install-win.cmd',
+    'install-win.ps1', 'uninstall-win.ps1', 'apply-update.ps1',
+    path.join('win', 'setup.sed'), 'verify-win.cmd',
+  ];
+  try {
+    for (const relative of required) {
+      const target = path.join(scriptsDir, relative);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(path.join(repoRoot, 'scripts', relative), target);
+    }
+    const result = spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/c', 'call', path.join(scriptsDir, 'verify-win.cmd')], {
+      encoding: 'utf8',
+      env: isolatedEnv(dir),
+      timeout: 10000,
+      windowsHide: true,
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('Windows verifier restores the caller code page', { skip: process.platform !== 'win32' }, () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workdaddy-verify-win-codepage-'));
+  const isolatedScript = path.join(dir, 'verify-win.cmd');
+  const wrapper = path.join(dir, 'verify-wrapper.cmd');
+  try {
+    fs.copyFileSync(verifyScript, isolatedScript);
+    fs.writeFileSync(wrapper, [
+      '@echo off',
+      'chcp 437 >nul',
+      'call verify-win.cmd',
+      'set "VERIFY_STATUS=%ERRORLEVEL%"',
+      'for /f "tokens=2 delims=:" %%C in (\'chcp\') do set "AFTER_CP=%%C"',
+      'echo VERIFY_STATUS=%VERIFY_STATUS%',
+      'echo AFTER_CP=%AFTER_CP%',
+      'exit /b 0',
+      '',
+    ].join('\r\n'), 'ascii');
+    const result = spawnSync(process.env.ComSpec || 'cmd.exe', ['/d', '/c', 'call', wrapper], {
+      encoding: 'utf8',
+      env: isolatedEnv(dir),
+      timeout: 10000,
+      windowsHide: true,
+      cwd: dir,
+    });
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, /VERIFY_STATUS=1/);
+    assert.match(result.stdout, /AFTER_CP=\s*437/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- return a stable success or failure code from the Windows package verifier
- preserve and restore the caller code page
- avoid interactive pause in CI while retaining local double-click behavior
- keep the complete upstream and stacked runtime-file matrix in the success fixture

## Why

The verifier could report failures in its output but still terminate successfully, allowing an incomplete Windows package to pass automation.

## Verification

- verifier contract: success, missing-file failure, and code-page restoration cases passed
- final rebased stack: 154 passed, 0 failed across 17 test files
- Windows batch verification ran on the current host
- `git diff --check`

## Stack and review order

This is PR 5 of 7. It depends on #24 and should be merged after it. Because the head branch is in a fork, this PR targets `main` and temporarily includes predecessor commits; review the tip commit for this scope until #21-#24 merge.

Tip commit for this scope: `a6256de`.

## Acceptance boundary

This validates the verifier against source-package fixtures; it does not build or install a release artifact.
