### PR TITLE
fix(ui): escape renderer data before HTML insertion

### DIFF
--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -213,6 +213,9 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     return false;
   }
 
+  function esc(t) { return String(t == null ? '' : t).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+  function escAttr(t) { return esc(t).replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+
   function checkinHtml(a) {
     // 国际版不开放签到活动：积分卡上的签到标签整体不展示（CN 版保留完整逻辑）
     if (PROFILE_ID === 'workbuddy-ai') return '';
@@ -228,13 +231,13 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     if (c.ok) return '<span class="wbs-ck wbs-checkin-tag ok">今日已签到✓</span>';
     // 认证类错误（401/未授权）统一显示友好文案（daemon 已产出，缓存残留旧文案时兜底）
     if (/401|Unauthorized|未授权|登录身份过期/.test(msg)) msg = '登录身份过期';
-    return '<span class="wbs-ck wbs-checkin-tag fail">' + msg + '</span>';
+    return '<span class="wbs-ck wbs-checkin-tag fail">' + esc(msg) + '</span>';
   }
 
-  function el(tag, cls, html) {
+  function el(tag, cls, text) {
     var n = document.createElement(tag);
     if (cls) n.className = cls;
-    if (html !== undefined) n.innerHTML = html;
+    if (text !== undefined) n.textContent = String(text);
     return n;
   }
 
@@ -536,7 +539,8 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     }
     function toast(msg, isErr, targetRoot) {
       if (!alive) return;
-      var t = el('div', 'wbs-toast' + (isErr ? ' err' : ''), msg);
+      var t = el('div', 'wbs-toast' + (isErr ? ' err' : ''));
+      t.textContent = String(msg == null ? '' : msg);
       (targetRoot || document.body).appendChild(t);
       setBuildTimeout(function () {
         t.classList.add('out');
@@ -1997,7 +2001,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         var html = '<option value="">' + esc(curName) + '</option>';
         accts.forEach(function (a) {
           if (a.uid === curUid) return;
-          html += '<option value="' + a.uid + '">' + esc(a.nickname || '账号' + a.uid.slice(0, 4)) + '</option>';
+          html += '<option value="' + escAttr(a.uid) + '">' + esc(a.nickname || '账号' + a.uid.slice(0, 4)) + '</option>';
         });
         html += '<option value="*">全部账号</option>';
         sel.innerHTML = html;
@@ -2038,7 +2042,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         }
         updateSessCount();
       }).catch(function (e) {
-        listEl.innerHTML = '<div class="wbs-empty">会话加载失败: ' + (e.message || e) + '</div>';
+        listEl.innerHTML = '<div class="wbs-empty">会话加载失败: ' + esc(e.message || e) + '</div>';
       });
     }
 
@@ -2087,7 +2091,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
           var title = s.custom_title || s.title || '(无标题)';
           html += '<div class="wbs-sess-row">' +
             '<span class="wbs-sess-main"><span class="wbs-sess-title">' + esc(title) + '</span>' +
-            '<span class="wbs-sess-meta">' + fmtHumanTime(s.last_activity_at || s.updated_at || s.created_at) + '</span></span>' +
+            '<span class="wbs-sess-meta">' + esc(fmtHumanTime(s.last_activity_at || s.updated_at || s.created_at)) + '</span></span>' +
             '</div>';
         });
         if (taskMore > 0) html += '<button class="wbs-sess-more" type="button" data-ws="__TASKS__">展开 ' + Math.min(taskMore, SESS_WS_STEP) + ' 条（剩余 ' + taskMore + '）</button>';
@@ -2117,7 +2121,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
           html += '<div class="wbs-sess-row">' +
             (batch ? '<input type="checkbox" class="wbs-sess-check" data-id="' + escAttr(s.id) + '"' + sel + '>' : '') +
             '<span class="wbs-sess-main"><span class="wbs-sess-title">' + esc(title) + '</span>' +
-            '<span class="wbs-sess-meta">' + fmtHumanTime(s.last_activity_at || s.updated_at || s.created_at) + '</span></span>' +
+            '<span class="wbs-sess-meta">' + esc(fmtHumanTime(s.last_activity_at || s.updated_at || s.created_at)) + '</span></span>' +
             (batch ? '' : autoCopyButton('session', s.id, s.user_id, marked, inherited)) +
             '</div>';
         });
@@ -2282,8 +2286,6 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
       }
       if (lbl) lbl.textContent = allSel ? '取消全选' : '全选';
     }
-    function esc(t) { return String(t == null ? '' : t).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
-    function escAttr(t) { return esc(t).replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
     // 人性化时间：刚刚 / x 分钟前 / x 小时前 / 昨天 / x 天前 / 日期
     function fmtHumanTime(ts) {
       if (!ts) return '-';
@@ -2416,7 +2418,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
           body.innerHTML = '<select class="wbs-sess-select wbs-sess-target" id="wbs-sess-target" title="选择目标账号">' +
             '<option value="">选择目标账号…</option>' +
             targets.map(function (a) {
-              return '<option value="' + a.uid + '">' + esc(a.nickname || a.uid) + (a.phone ? '（' + esc(a.phone) + '）' : '') + '</option>';
+              return '<option value="' + escAttr(a.uid) + '">' + esc(a.nickname || a.uid) + (a.phone ? '（' + esc(a.phone) + '）' : '') + '</option>';
             }).join('') +
             '</select>';
         }
@@ -2526,9 +2528,9 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
       // 按钮组占流固定在标题行右侧，仅 hover/focus cell 时由透明变不透明，布局与高度恒定
       var actions = options.official
         ? '<div class="wbs-model-actions">' +
-          '<button class="wbs-model-icon-action" type="button" data-model-backup="' + model.index + '" title="备份" aria-label="备份">' + MODEL_BACKUP_SVG + '</button>' +
-          '<button class="wbs-model-icon-action" type="button" data-model-test="' + model.index + '" title="连通测试" aria-label="连通测试">' + MODEL_TEST_SVG + '</button>' +
-          '<button class="wbs-model-icon-action wbs-model-danger-action" type="button" data-model-delete-official="' + model.index + '" title="删除" aria-label="删除">' + TRASH_SVG + '</button>' +
+          '<button class="wbs-model-icon-action" type="button" data-model-backup="' + escAttr(model.index) + '" title="备份" aria-label="备份">' + MODEL_BACKUP_SVG + '</button>' +
+          '<button class="wbs-model-icon-action" type="button" data-model-test="' + escAttr(model.index) + '" title="连通测试" aria-label="连通测试">' + MODEL_TEST_SVG + '</button>' +
+          '<button class="wbs-model-icon-action wbs-model-danger-action" type="button" data-model-delete-official="' + escAttr(model.index) + '" title="删除" aria-label="删除">' + TRASH_SVG + '</button>' +
           '</div>'
         : '<div class="wbs-model-actions">' +
           '<button class="wbs-model-icon-action" type="button" data-model-copy="' + escAttr(model.backupId) + '" title="复制" aria-label="复制">' + MODEL_COPY_SVG + '</button>' +
@@ -3451,10 +3453,11 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         if (!list.length) { grid.innerHTML = '<div class="wbs-wp-loading">暂无官方壁纸</div>'; return; }
         var html = '';
         list.forEach(function (w) {
+          var wallpaperUrl = base + '/wallpapers/' + encodeURIComponent(w.name);
           html +=
-            '<div class="wbs-wp" data-wp="' + w.name + '" title="' + w.title + '">' +
-            '<div class="wbs-wp-thumb"><img data-src="' + base + '/wallpapers/' + encodeURIComponent(w.name) + '" alt="' + w.title + '" loading="lazy"></div>' +
-            '<div class="wbs-wp-badge">' + (String(w.name).replace(/\D/g, '').replace(/^0+/, '') || w.title) + '</div>' +
+            '<div class="wbs-wp" data-wp="' + escAttr(w.name) + '" title="' + escAttr(w.title) + '">' +
+            '<div class="wbs-wp-thumb"><img data-src="' + escAttr(wallpaperUrl) + '" alt="' + escAttr(w.title) + '" loading="lazy"></div>' +
+            '<div class="wbs-wp-badge">' + esc(String(w.name).replace(/\D/g, '').replace(/^0+/, '') || w.title) + '</div>' +
             '</div>';
         });
         grid.innerHTML = html;
@@ -3860,12 +3863,12 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         ['圆角', cs.borderRadius], ['模糊', cs.backdropFilter === 'none' ? '—' : cs.backdropFilter],
       ];
       for (var i = 0; i < items.length; i++) {
-        rows += '<div class="wbs-ins-row"><span>' + items[i][0] + '</span><code>' + (items[i][1] || '—') + '</code></div>';
+        rows += '<div class="wbs-ins-row"><span>' + esc(items[i][0]) + '</span><code>' + esc(items[i][1] || '—') + '</code></div>';
       }
       var vars = '';
       for (var k = 0; k < INSPECT_KEYS.length; k++) {
         var v = cs.getPropertyValue(INSPECT_KEYS[k][0]).trim();
-        vars += '<div class="wbs-ins-row"><span>' + INSPECT_KEYS[k][1] + ' <em>' + INSPECT_KEYS[k][0] + '</em></span><code>' + (v || '未定义（继承上层）') + '</code></div>';
+        vars += '<div class="wbs-ins-row"><span>' + esc(INSPECT_KEYS[k][1]) + ' <em>' + esc(INSPECT_KEYS[k][0]) + '</em></span><code>' + esc(v || '未定义（继承上层）') + '</code></div>';
       }
       var rules = [];
       try {
@@ -3882,7 +3885,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         }
       } catch (e) {}
       var rulesHtml = rules.length
-        ? rules.map(function (x) { return '<div class="wbs-ins-rule">' + x + '</div>'; }).join('')
+        ? rules.map(function (x) { return '<div class="wbs-ins-rule">' + esc(x) + '</div>'; }).join('')
         : '<div class="wbs-ins-rule muted">无直接样式规则（颜色来自继承）</div>';
       // 完整报告文本（复制用：选择器 + 基础样式 + 主题变量 + 匹配规则）
       var report = ['🔍 ' + buildSelector(el), ''];
@@ -3901,9 +3904,9 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
       // 元素 query 路径（从 body 到该元素的完整 CSS 选择器，可直接用于 document.querySelector）
       var queryPath = buildQueryPath(el);
       div.innerHTML =
-        '<div class="wbs-ins-head"><span>🔍 ' + buildSelector(el) + '</span>' +
+        '<div class="wbs-ins-head"><span>🔍 ' + esc(buildSelector(el)) + '</span>' +
         '<span class="wbs-ins-btns"><button class="wbs-ins-copy" type="button" title="复制元素 query 路径（从 body 起的完整 CSS 选择器）">复制路径</button><button class="wbs-ins-repick" type="button">再检查</button><button class="wbs-ins-close" type="button">✕</button></span></div>' +
-        '<div class="wbs-ins-sec">元素路径</div><div class="wbs-ins-path">' + queryPath + '</div>' +
+        '<div class="wbs-ins-sec">元素路径</div><div class="wbs-ins-path">' + esc(queryPath) + '</div>' +
         '<div class="wbs-ins-sec">基础样式</div>' + rows +
         '<div class="wbs-ins-sec">主题变量（当前生效值）</div>' + vars +
         '<div class="wbs-ins-sec">匹配的样式规则</div>' + rulesHtml +
@@ -4843,8 +4846,8 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         var ops = isCur
           ? ''
           : '<div class="wbs-ops">' +
-            (expired ? '' : '<button class="wbs-icon-btn wbs-acc-switch" type="button" title="切换" data-uid="' + a.uid + '" data-name="' + (a.nickname || '未命名') + '">' + SWITCH_SVG + '</button>') +
-            '<button class="wbs-icon-btn wbs-del" type="button" title="删除" data-uid="' + a.uid + '" data-name="' + (a.nickname || '未命名') + '">' + TRASH_SVG + '</button>' +
+            (expired ? '' : '<button class="wbs-icon-btn wbs-acc-switch" type="button" title="切换" data-uid="' + escAttr(a.uid) + '" data-name="' + escAttr(a.nickname || '未命名') + '">' + SWITCH_SVG + '</button>') +
+            '<button class="wbs-icon-btn wbs-del" type="button" title="删除" data-uid="' + escAttr(a.uid) + '" data-name="' + escAttr(a.nickname || '未命名') + '">' + TRASH_SVG + '</button>' +
             '</div>';
         // 国际版没有手机号：用 UIN（账号唯一数字标识）替代展示；国内版仍显示手机。
         // wbs-uin-cell 用于 UIN 模式下补齐标签与取值之间的间距（wbs-phone-cell 默认 gap:0 过于紧凑）。
@@ -4853,10 +4856,10 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
         var idVal = a.phone ? esc(a.phone) : (a.uin ? esc(a.uin) : '-');
         card.innerHTML =
           '<div class="wbs-info">' +
-          '<div class="wbs-row1"><div class="wbs-name-group"><span class="wbs-name">' + (a.nickname || '(未命名)') + '</span>' + badge + '</div>' + ops + '</div>' +
+          '<div class="wbs-row1"><div class="wbs-name-group"><span class="wbs-name">' + esc(a.nickname || '(未命名)') + '</span>' + badge + '</div>' + ops + '</div>' +
           '<div class="wbs-meta wbs-secondary-row">' +
           '<div class="wbs-mi wbs-phone-cell' + (isUinMode ? ' wbs-uin-cell' : '') + '"><span class="wbs-lbl">' + idLbl + '</span><span class="wbs-val">' + idVal + '</span></div>' +
-          '<div class="wbs-mi wbs-token-cell"><span class="wbs-lbl">有效期至</span><span class="wbs-val' + (ts.warn ? ' wbs-warn' : '') + '">' + ts.label + '</span></div>' +
+          '<div class="wbs-mi wbs-token-cell"><span class="wbs-lbl">有效期至</span><span class="wbs-val' + (ts.warn ? ' wbs-warn' : '') + '">' + esc(ts.label) + '</span></div>' +
           '</div>' +
           '<div class="wbs-credit-cell' + (isIdentityExpired(a) ? ' wbs-credit-hidden' : '') + '">' + creditBlockHtml(credits, a.creditSegments, a) + '</div>' +
           '</div>';
@@ -4960,7 +4963,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
           fetchCreditsForAccounts();
         })
         .catch(function (e) {
-          var msg = '<div class="wbs-empty">无法连接本地服务: ' + e.message + '<br>请确认守护进程已运行</div>';
+          var msg = '<div class="wbs-empty">无法连接本地服务: ' + esc(e.message || e) + '<br>请确认守护进程已运行</div>';
           accountsPane.innerHTML = msg;
         });
     }

--- a/test/renderer-escaping.test.js
+++ b/test/renderer-escaping.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'scripts', 'inject.js'), 'utf8');
+
+function sourceBetween(start, end) {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.ok(startIndex >= 0 && endIndex > startIndex, `missing source block ${start}`);
+  return source.slice(startIndex, endIndex);
+}
+
+test('HTML and attribute escaping cover markup and quoted attributes', () => {
+  const escapeSource = sourceBetween('function esc(t)', 'function checkinHtml');
+  const getHelpers = new Function(`${escapeSource}; return { esc, escAttr };`);
+  const { esc, escAttr } = getHelpers();
+  assert.equal(esc('<img src=x onerror=1>&'), '&lt;img src=x onerror=1&gt;&amp;');
+  assert.equal(escAttr('"\' <x> &'), '&quot;&#39; &lt;x&gt; &amp;');
+  const payload = '\"><img src=x onerror=alert(1)>\'&';
+  const rendered = `<button data-name="${escAttr(payload)}">${esc(payload)}</button>`;
+  assert.doesNotMatch(rendered, /<img/i);
+  assert.doesNotMatch(rendered, /data-name="">/i);
+});
+
+test('toast content is always written as text', () => {
+  const toast = sourceBetween('function toast(msg', 'registerDisposer(function () {');
+  assert.match(toast, /textContent\s*=\s*String\(msg/);
+  assert.doesNotMatch(toast, /el\([^\n]+,\s*msg\s*\)/);
+  const elementHelper = sourceBetween('function el(tag', 'function maskPhone');
+  assert.match(elementHelper, /textContent\s*=\s*String\(text\)/);
+  assert.doesNotMatch(elementHelper, /innerHTML/);
+});
+
+test('session and account selectors escape every text and attribute sink', () => {
+  const accountSelect = sourceBetween('function loadSessionAccounts()', 'function loadSessions()');
+  assert.match(accountSelect, /'<option value="' \+ escAttr\(a\.uid\) \+ '">' \+ esc\(a\.nickname/);
+  assert.doesNotMatch(accountSelect, /'<option value="' \+ a\.uid/);
+  assert.doesNotMatch(accountSelect, /\+ \(a\.nickname \|\|/);
+
+  const copyModal = sourceBetween('function openCopyModal(ids)', 'function openDeleteModal(ids)');
+  assert.match(copyModal, /'<option value="' \+ escAttr\(a\.uid\) \+ '">' \+ esc\(a\.nickname \|\| a\.uid\)/);
+  assert.match(copyModal, /a\.phone \? '[^']*' \+ esc\(a\.phone\)/);
+  assert.doesNotMatch(copyModal, /'<option value="' \+ a\.uid/);
+
+  const sessions = sourceBetween('function renderSessions()', 'function activeAutoCopyCount()');
+  assert.equal((sessions.match(/escAttr\(key\)/g) || []).length, 1);
+  assert.equal((sessions.match(/escAttr\(uid\)/g) || []).length, 1);
+  assert.equal((sessions.match(/escAttr\(s\.id\)/g) || []).length, 1);
+  assert.equal((sessions.match(/esc\(title\)/g) || []).length, 2);
+  assert.equal((sessions.match(/esc\(fmtHumanTime\(/g) || []).length, 2);
+  assert.match(sessions, /title="' \+ escAttr\(group\.cwd\)/);
+  assert.match(sessions, /esc\(shortWs\(group\.cwd\)\)/);
+  assert.doesNotMatch(sessions, /data-(?:auto-key|auto-uid|id)="' \+ (?:key|uid|s\.id)/);
+});
+
+test('model, wallpaper, and account cards escape each dynamic HTML sink', () => {
+  const models = sourceBetween('function modelRowHtml(model, options)', 'function loadModels()');
+  assert.equal((models.match(/escAttr\(model\.index\)/g) || []).length, 3);
+  assert.equal((models.match(/escAttr\(model\.backupId\)/g) || []).length, 3);
+  assert.match(models, /escAttr\(selectionKey\)/);
+  assert.match(models, /title="' \+ escAttr\(model\.name \|\| model\.id/);
+  assert.match(models, /'">' \+ esc\(model\.name \|\| model\.id/);
+  assert.doesNotMatch(models, /data-model-(?:backup|test|delete-official)="' \+ model\.index/);
+  assert.doesNotMatch(models, /data-model-(?:copy|edit|enable)="' \+ model\.backupId/);
+
+  const wallpapers = sourceBetween('function loadWallpapers()', 'function setOpen(open)');
+  assert.match(wallpapers, /data-wp="' \+ escAttr\(w\.name\)/);
+  assert.match(wallpapers, /title="' \+ escAttr\(w\.title\)/);
+  assert.match(wallpapers, /data-src="' \+ escAttr\(wallpaperUrl\)/);
+  assert.match(wallpapers, /alt="' \+ escAttr\(w\.title\)/);
+  assert.match(wallpapers, /wbs-wp-badge">' \+ esc\(/);
+  assert.doesNotMatch(wallpapers, /(?:data-wp|title|data-src|alt)="' \+ (?:w\.|wallpaperUrl)/);
+
+  const accounts = sourceBetween('function render(data)', 'function updateAccountSummary()');
+  assert.equal((accounts.match(/escAttr\(a\.uid\)/g) || []).length, 2);
+  assert.equal((accounts.match(/escAttr\(a\.nickname \|\| '未命名'\)/g) || []).length, 2);
+  assert.match(accounts, /var idVal = a\.phone \? esc\(a\.phone\) : \(a\.uin \? esc\(a\.uin\) : '-'\)/);
+  assert.match(accounts, /wbs-name">' \+ esc\(a\.nickname/);
+  assert.match(accounts, /wbs-val">' \+ idVal/);
+  assert.match(accounts, /wbs-val[^\n]+esc\(ts\.label\)/);
+  assert.doesNotMatch(accounts, /data-(?:uid|name)="' \+ a\./);
+  assert.doesNotMatch(accounts, /var idVal = a\.phone \? a\.phone/);
+});
+
+test('dynamic error and check-in messages are escaped before HTML insertion', () => {
+  assert.match(source, /wbs-checkin-tag fail[^\n]+esc\(msg\)/);
+  assert.match(source, /会话加载失败: ' \+ esc\(e\.message \|\| e\)/);
+  assert.match(source, /模型加载失败：' \+ esc\(e\.message \|\| e\)/);
+  assert.match(source, /无法连接本地服务: ' \+ esc\(e\.message \|\| e\)/);
+  assert.doesNotMatch(source, /innerHTML\s*=\s*'[^\n]*'\s*\+\s*\(e\.message \|\| e\)/);
+});
+
+test('inspector escapes page-controlled selectors and computed style values', () => {
+  const inspector = sourceBetween('function showInspector(el)', 'function stopInspect()');
+  assert.match(inspector, /esc\(buildSelector\(el\)\)/);
+  assert.match(inspector, /esc\(queryPath\)/);
+  assert.match(inspector, /esc\(items\[i\]\[1\] \|\| '—'\)/);
+  assert.match(inspector, /esc\(v \|\| '未定义（继承上层）'\)/);
+  assert.match(inspector, /rules\.map\(function \(x\) \{ return '[^\n]+' \+ esc\(x\)/);
+  assert.doesNotMatch(inspector, /\+ buildSelector\(el\) \+/);
+  assert.doesNotMatch(inspector, /\+ queryPath \+/);
+  assert.doesNotMatch(inspector, /<code>' \+ \(items\[i\]\[1\]/);
+  assert.doesNotMatch(inspector, /<code>' \+ \(v \|\|/);
+  assert.doesNotMatch(inspector, /wbs-ins-rule">' \+ x \+/);
+});


### PR DESCRIPTION
## Summary

- escape dynamic text and attribute values before HTML insertion
- use `textContent` for toast and element text paths
- cover session, account, model, wallpaper, error, check-in, and inspector values
- preserve upstream no-disturb and session-health behavior around the changed renderer code

## Why

Local and API-derived values were interpolated into HTML in several renderer paths. A malicious or malformed value could cross into markup, attribute, or event-handler contexts.

## Verification

- renderer escaping suite: 6 passed, 0 failed
- final rebased stack: 154 passed, 0 failed across 17 test files
- final Claude Opus 4.6 review confirmed escaping helpers, `textContent` paths, and adjacent upstream UI behavior
- key JavaScript syntax checks and `git diff --check` passed

## Stack and review order

This is PR 7 of 7. It depends on #26 and should be merged last. Because the head branch is in a fork, this PR targets `main` and temporarily includes predecessor commits; review the tip commit for this scope until #21-#26 merge.

Tip commit for this scope: `f1db9b3`.

## Acceptance boundary

The renderer sinks are covered structurally and by unit tests. A real Electron window and interactive no-disturb/session-health workflow were not exercised in this session.
