### PR TITLE
fix(update): prevent upgrade deadlock on non-default install path (#51)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Update deadlock recovery tests (issue #51)
+        run: node --test test/update-deadlock-recovery.test.js
+      - name: Existing boundary contract tests
+        run: |
+          node --test test/windows-powershell-boundary.test.js
+          node --test test/windows-privilege-boundary.test.js

--- a/docs/issue-51-fix.md
+++ b/docs/issue-51-fix.md
@@ -1,0 +1,61 @@
+# Issue #51 修复：升级死锁自愈
+
+## 根因
+
+`apply-update.ps1` 的早期校验（权限/boundary/路径）位于日志初始化与主 `try/finally` **之前**，失败时静默退出：`apply.log` 不存在、`pending.json` 残留 → watchdog 检测到标记后**永久拒绝**重启 daemon → 应用卡在「启动较慢」。
+
+触发条件：1.1.1 装在非默认目录（如 D 盘），daemon 认定路径与脚本实际位置不一致，路径校验 throw。
+
+## 改动（2 个文件）
+
+### `scripts/apply-update.ps1`
+
+1. **权限探针**保留在目录创建前（`windows-powershell-boundary` 契约要求），但失败时不再 `exit 5`，改为记录 `$privilegeError` 变量，延后到主 try 内 throw（此时 transcript 已启动 → 有日志）。
+2. **boundary 加载 + 路径检查**移入主 try：失败会写入 `apply.log` 并由 finally 清理 `pending.json`。
+3. **finally 无条件清理** `pending.json`，移除 `$lifecycleValidated` 门控（原门控导致「停止 watchdog 之前」的失败跳过清理）。
+
+### `scripts/watchdog.js`
+
+1. 新增 `schedulePendingRecheck()`：跳过 daemon 重启时启动 15s 复查定时器。
+2. 标记被 apply 脚本删除、或宽限期满被 `updatePendingIsActive()` 清理后，**自动重新拉起 daemon**——形成自愈闭环。
+3. `shutdown()` 清理定时器，避免泄漏。
+
+原实现：watchdog 检查一次 `pending.json` → 标记存在 → `return`，从此再无人复查。`updatePendingIsActive()` 内置的 10 分钟宽限清理是**死代码**。
+
+## 测试
+
+### 运行测试
+
+```bash
+# 在仓库根目录
+node --test test/update-deadlock-recovery.test.js
+
+# Windows 上还需确认现有契约测试未被破坏
+node --test test/windows-powershell-boundary.test.js
+node --test test/windows-privilege-boundary.test.js
+```
+
+### 测试覆盖（5 个）
+
+| # | 测试 | 类型 | 验证 |
+|---|------|------|------|
+| 1 | early validation lives inside main try | 静态 | boundary 加载与路径检查在 `Write-ApplyLog "start"` 之后；权限失败的 `if ($privilegeError)` throw 也在 start 之后（transcript 已启动） |
+| 2 | finally clears pending.json unconditionally | 静态 | finally 块清理 `pending.json` 不被 `if` 门控，无 `$lifecycleValidated` |
+| 3 | schedulePendingRecheck provides self-healing loop | 静态 | watchdog 定义 `schedulePendingRecheck`，函数体复查 `updatePendingIsActive` 并调 `startDaemon`，shutdown 清理定时器 |
+| 4 | path-mismatch failure writes apply.log and clears pending.json | Windows 行为 | 精确复现 issue #51 场景（路径不一致 throw），验证 `apply.log` 已生成 + `pending.json` 已删除 |
+| 5 | missing-package failure still clears pending.json | Windows 行为 | 中期失败（包不存在）也清 `pending.json`（原 `lifecycleValidated` 门控会跳过） |
+
+### 手动端到端验证（可选）
+
+1. 在测试环境装 1.1.1 到非默认目录（如 D 盘）
+2. 触发升级到 1.1.2（让 daemon spawn apply-update.ps1）
+3. 预期：`apply.log` 存在且记录路径不一致错误，`pending.json` 被清理，watchdog 15s 内自动拉起 daemon
+4. 确认 GUI 不再卡「启动较慢」
+
+## 提 PR
+
+```bash
+git push origin fix/update-deadlock-recovery
+gh pr create --title "fix(update): prevent upgrade deadlock on non-default install path (#51)" \
+  --body "See test/update-deadlock-recovery.test.js for the deadlock contract and regression coverage."
+```

--- a/scripts/apply-update.ps1
+++ b/scripts/apply-update.ps1
@@ -1,5 +1,9 @@
 ﻿# WorkDaddy Windows 自动更新替换脚本。
 # 独立于 daemon 运行：停止 watchdog、替换安装目录、启动新版并验证 API；失败时保留日志并回滚。
+# 【防死锁契约】daemon 在 spawn 本脚本前已写入 update/pending.json 且自我退出，watchdog 检测到
+# 该标记后不会重启 daemon（防端口抢占竞态）。因此本脚本无论成功、失败还是早期校验不过，
+# 退出前都必须：① 写 apply.log 留证 ② 删除 pending.json。任何绕过这两步的退出路径都会把
+# 应用留在「daemon 已死、watchdog 永不拉起」的永久卡死状态（issue #51 的死锁根因）。
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)][Alias('SrcZip')][string]$SrcPackage,
@@ -10,28 +14,25 @@ param(
   [string]$Profile = '__WBS_DEFAULT_PROFILE__'
 )
 
+# 【防死锁加固】boundary 加载与路径一致性校验原先位于日志初始化与主 try/finally 之前，
+# 失败会静默退出：apply.log 不存在、pending.json 残留，无从排查且造成 watchdog 永久拒启
+# （issue #51）。现移入主 try：失败会写入 apply.log 并由 finally 无条件清理 pending.json。
+# 权限探针保留在目录创建与日志初始化之前（windows-powershell-boundary 契约要求），
+# 但失败时不再 exit 5，改为记录错误延后到主 try 内 throw，确保 transcript 已启动 → 有日志。
+$ErrorActionPreference = 'Stop'
+$privilegeError = $null
 try {
   $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
   $principal = New-Object Security.Principal.WindowsPrincipal($identity)
   $isElevated = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
   $env:WBSWITCH_PRIVILEGE_MODE = if ($isElevated) { 'elevated' } else { 'standard' }
 } catch {
-  [Console]::Error.WriteLine('无法确认当前 PowerShell 的 Windows 权限模式；更新已停止。')
-  exit 5
-}
-
-$ErrorActionPreference = 'Stop'
-try { . (Join-Path $PSScriptRoot 'windows-process-boundary.ps1') } catch {
-  [Console]::Error.WriteLine('无法加载 Windows 进程身份边界；更新已停止。')
-  exit 5
+  $privilegeError = "无法确认 PowerShell 权限模式: $($_.Exception.Message)"
 }
 if ([string]::IsNullOrWhiteSpace($Profile) -or $Profile -eq '__WBS_DEFAULT_PROFILE__') { $Profile = 'workbuddy-cn' }
 if ($Profile -ne 'workbuddy-ai') { $Profile = 'workbuddy-cn' }
 $productName = if ($Profile -eq 'workbuddy-ai') { 'WorkDaddy AI' } else { 'WorkDaddy' }
 if ([string]::IsNullOrWhiteSpace($AppDir)) { $AppDir = Join-Path $env:LOCALAPPDATA (Join-Path 'Programs' $productName) }
-if (-not (Test-SameWindowsPath -Left $PSScriptRoot -Right (Join-Path $AppDir 'scripts'))) {
-  throw '更新脚本位置与目标安装目录不一致，拒绝替换'
-}
 $dataRoot = Join-Path $env:APPDATA 'WorkDaddy'
 $DataDir = if ($Profile -eq 'workbuddy-ai') { Join-Path $dataRoot 'profiles\workbuddy-ai' } else { $dataRoot }
 $LogDir = Join-Path $DataDir 'update'
@@ -98,15 +99,30 @@ function Rollback-App {
 $oldDir = "$AppDir.old"
 $tmpDir = Join-Path $env:TEMP ("workdaddy-update-" + [guid]::NewGuid().ToString('N'))
 $backupMade = $false
-$lifecycleValidated = $false
 $isSetupPackage = $false
 try {
   Write-ApplyLog "start attempt=$AttemptId src=$SrcPackage dst=$AppDir port=$Port pid=$PID"
+
+  # 【校验 1】权限模式已在脚本顶部探测（契约：探针须在 New-Item/Start-Transcript 前）。
+  # 顶部失败时只记录错误，延后到此 throw：transcript 已启动 → 有日志，finally → 清 pending。
+  if ($privilegeError) { throw $privilegeError }
+
+  # 【校验 2】加载 Windows 进程身份边界（提供 Test-SameWindowsPath / 停进程等函数）。
+  try { . (Join-Path $PSScriptRoot 'windows-process-boundary.ps1') } catch {
+    throw "无法加载 Windows 进程身份边界: $($_.Exception.Message)"
+  }
+
+  # 【校验 3】路径一致性防误替换（安全网，保留原语义；典型触发：非标准目录安装 +
+  # daemon 传入了与脚本实际位置不一致的目标目录）。失败现在会留日志并清标记，
+  # 而不是静默崩溃把应用留在死锁态。
+  if (-not (Test-SameWindowsPath -Left $PSScriptRoot -Right (Join-Path $AppDir 'scripts'))) {
+    throw "更新脚本位置与目标安装目录不一致，拒绝替换（实际脚本: $PSScriptRoot，目标: $AppDir）"
+  }
+
   if (-not (Test-Path -LiteralPath $SrcPackage -PathType Leaf)) { throw "更新包不存在: $SrcPackage" }
   $isSetupPackage = ([IO.Path]::GetExtension($SrcPackage) -ieq '.exe')
   Stop-WatchdogAndPort
   Stop-WorkBuddyForUpdate
-  $lifecycleValidated = $true
 
   foreach ($launcherPath in @((Join-Path $AppDir 'scripts\launcher.cmd'), (Join-Path $oldDir 'scripts\launcher.cmd'))) {
     if (-not (Release-VerifiedLauncherLock -LauncherPath $launcherPath)) { throw "无法释放 launcher.cmd 文件锁: $launcherPath" }
@@ -204,8 +220,10 @@ try {
   Stop-ApplyTranscript
   exit 1
 } finally {
-  if ($lifecycleValidated) {
-    try { if (Test-Path -LiteralPath $tmpDir) { Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue } } catch {}
-    try { Remove-Item -LiteralPath (Join-Path $LogDir 'pending.json') -Force -ErrorAction SilentlyContinue } catch {}
-  }
+  # 【防死锁契约 · 兜底】本脚本是唯一的更新执行者：无论走到哪一步退出（含早期校验失败），
+  # 更新流程都已结束，pending.json 必须删除，否则 watchdog 将永久拒绝重启 daemon。
+  # 原实现以 $lifecycleValidated 门控本清理，导致「停止 watchdog 之前」的任何失败
+  # （路径不一致、包缺失等）都会残留标记 → issue #51 永久卡死。现改为无条件清理。
+  try { if (Test-Path -LiteralPath $tmpDir) { Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue } } catch {}
+  try { Remove-Item -LiteralPath (Join-Path $LogDir 'pending.json') -Force -ErrorAction SilentlyContinue } catch {}
 }

--- a/scripts/watchdog.js
+++ b/scripts/watchdog.js
@@ -259,6 +259,30 @@ fs.writeFileSync(PID_FILE, String(process.pid), { flag: 'wx' });
 let child = null;
 let stopping = false;
 let restartDelay = 3000; // 初始 3s，连续崩溃递增，上限 60s
+let pendingRecheckTimer = null; // 更新等待期复查定时器（防死锁：见 schedulePendingRecheck）
+
+function schedulePendingRecheck() {
+  // 【防死锁加固】原实现：daemon 在更新窗口内退出 → watchdog 检查一次 pending.json →
+  // 标记存在（或宽限期内）→ 直接 return，从此再无人复查。updatePendingIsActive() 内置的
+  // 10 分钟宽限清理逻辑因此成为死代码——apply-update.ps1 若在任何未清理标记的路径上崩溃
+  // （issue #51：早期校验 throw 在 finally 之前），watchdog 将永久拒绝拉起 daemon。
+  // 现在：跳过重启时启动本定时器，持续复查标记；标记被 apply 脚本删除、或宽限期满被
+  // updatePendingIsActive() 清理后，自动重新拉起 daemon，形成自愈闭环。
+  if (pendingRecheckTimer) return;
+  pendingRecheckTimer = setInterval(() => {
+    if (stopping) {
+      clearInterval(pendingRecheckTimer);
+      pendingRecheckTimer = null;
+      return;
+    }
+    if (updatePendingIsActive()) return; // 更新仍在进行（脚本活着或宽限期内）
+    clearInterval(pendingRecheckTimer);
+    pendingRecheckTimer = null;
+    if (child) return; // daemon 已在运行（外部拉起），无需干预
+    log('更新标记已清除，重新拉起 daemon');
+    startDaemon();
+  }, 15000);
+}
 
 function startDaemon() {
   if (stopping) return;
@@ -277,6 +301,7 @@ function startDaemon() {
     // 标记由 apply-update.ps1 成功/失败后删除；删除后靠新版 launcher/手动启动重新拉起。
     if (updatePendingIsActive()) {
       log('检测到更新标记 pending.json，跳过自动重启 daemon（等待 apply-update.ps1 完成替换）');
+      schedulePendingRecheck(); // 持续复查：脚本崩溃/标记过期后自动恢复，杜绝永久死锁
       return;
     }
     log('daemon 退出 code=' + code + ' signal=' + signal + '，' + restartDelay + 'ms 后重启');
@@ -293,6 +318,10 @@ startDaemon();
 function shutdown() {
   if (stopping) return;
   stopping = true;
+  if (pendingRecheckTimer) {
+    clearInterval(pendingRecheckTimer);
+    pendingRecheckTimer = null;
+  }
   log('watchdog 收到停止信号，结束 daemon');
   if (child) {
     try { child.kill(); } catch (_) {}

--- a/test/update-deadlock-recovery.test.js
+++ b/test/update-deadlock-recovery.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+/**
+ * 升级死锁自愈契约测试（issue #51）
+ *
+ * 验证 apply-update.ps1 + watchdog.js 的防死锁加固：
+ *   1. apply-update.ps1 的早期校验（权限/boundary/路径）必须位于主 try 内、
+ *      在 Write-ApplyLog "start" 之后；任何早期失败都会留下 apply.log。
+ *   2. apply-update.ps1 的 finally 块必须无条件清理 pending.json
+ *      （不再受 lifecycleValidated 门控，否则早期失败会残留标记）。
+ *   3. watchdog.js 在跳过 daemon 重启时必须启动 pendingRecheckTimer 持续复查，
+ *      标记被清除后自动重新拉起 daemon（原实现的 10 分钟宽限清理是死代码）。
+ *   4. （Windows 行为测试）路径不一致触发 throw 后，apply.log 已生成且
+ *      pending.json 已被清理——这是 issue #51 死锁的精确复现与回归保护。
+ */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const repoRoot = path.join(__dirname, '..');
+const scriptsDir = path.join(repoRoot, 'scripts');
+const applyScriptPath = path.join(scriptsDir, 'apply-update.ps1');
+const watchdogScriptPath = path.join(scriptsDir, 'watchdog.js');
+const applySource = fs.readFileSync(applyScriptPath, 'utf8');
+const watchdogSource = fs.readFileSync(watchdogScriptPath, 'utf8');
+
+// ---- 静态契约：apply-update.ps1 ----
+
+test('apply-update.ps1: early validation lives inside main try, after start log', () => {
+  const startIdx = applySource.indexOf('Write-ApplyLog "start attempt=');
+  assert.ok(startIdx >= 0, 'missing "start attempt" log line');
+
+  const tryIdx = applySource.lastIndexOf('try {', startIdx);
+  assert.ok(tryIdx >= 0 && tryIdx < startIdx, '"start" log must be inside main try');
+
+  // boundary 加载与路径检查必须在 start log 之后（修复前在前面，崩溃无日志 → issue #51）
+  for (const marker of ['windows-process-boundary.ps1', '更新脚本位置与目标安装目录不一致']) {
+    const idx = applySource.indexOf(marker);
+    assert.ok(idx > startIdx, `${marker} must appear after "start" log (was before, caused silent deadlock)`);
+  }
+
+  // 权限探针的 IsInRole 可在 start log 之前（windows-powershell-boundary 契约要求探针在副作用前），
+  // 但失败的 throw 必须在 start log 之后，确保 transcript 已启动 → 有日志
+  const privilegeThrow = applySource.indexOf('if ($privilegeError)');
+  assert.ok(privilegeThrow > startIdx, 'privilege failure throw must be after start log (so transcript captures it)');
+});
+
+test('apply-update.ps1: finally clears pending.json unconditionally (no lifecycleValidated gate)', () => {
+  const finallyIdx = applySource.lastIndexOf('} finally {');
+  assert.ok(finallyIdx >= 0, 'missing finally block');
+  const finallyBlock = applySource.slice(finallyIdx);
+
+  // pending.json 清理必须在 finally 内
+  assert.ok(/Remove-Item.*pending\.json/.test(finallyBlock), 'finally must remove pending.json');
+
+  // finally 块内不得出现 $lifecycleValidated 门控（原实现用它跳过早期失败的清理）
+  // 注：注释中解释「为何移除」时会提到该词，因此只检查实际的 if 门控结构
+  assert.ok(!/if\s*\([^)]*\$lifecycleValidated/i.test(finallyBlock), 'finally must not gate cleanup on $lifecycleValidated');
+
+  // pending.json 清理行本身不得被 if 包裹
+  const cleanupLine = finallyBlock
+    .split('\n')
+    .find((l) => /pending\.json/.test(l) && /Remove-Item/.test(l));
+  assert.ok(cleanupLine, 'must find pending.json cleanup line in finally');
+  assert.ok(!/if\s*\(/.test(cleanupLine), 'pending.json cleanup must not be gated by if');
+});
+
+// ---- 静态契约：watchdog.js ----
+
+test('watchdog: schedulePendingRecheck provides self-healing loop', () => {
+  assert.ok(/function schedulePendingRecheck\(\)/.test(watchdogSource), 'must define schedulePendingRecheck');
+
+  // 跳过 daemon 重启时必须调度复查
+  const skipIdx = watchdogSource.indexOf('跳过自动重启 daemon');
+  assert.ok(skipIdx >= 0, 'must have skip-restart log line');
+  const scheduleCallIdx = watchdogSource.indexOf('schedulePendingRecheck();', skipIdx);
+  assert.ok(scheduleCallIdx > 0, 'must call schedulePendingRecheck when skipping daemon restart');
+
+  // schedulePendingRecheck 函数体内必须复查 pending，标记清除后重新拉起 daemon
+  const fnDefIdx = watchdogSource.indexOf('function schedulePendingRecheck()');
+  const fnBody = watchdogSource.slice(fnDefIdx, watchdogSource.indexOf('\n}', fnDefIdx) + 2);
+  assert.ok(/updatePendingIsActive\(\)/.test(fnBody), 'schedulePendingRecheck body must re-check pending via updatePendingIsActive');
+  assert.ok(/startDaemon\(\)/.test(fnBody), 'schedulePendingRecheck body must re-pull daemon after marker clears');
+  assert.ok(/重新拉起 daemon/.test(fnBody), 'must log self-healing action');
+
+  // shutdown 时清理定时器，避免泄漏
+  assert.ok(/clearInterval\(pendingRecheckTimer\)/.test(watchdogSource), 'must clear pendingRecheckTimer on shutdown');
+});
+
+// ---- Windows 行为测试：精确复现 issue #51 死锁场景并验证自愈 ----
+
+test('apply-update.ps1: path-mismatch failure writes apply.log and clears pending.json', { skip: process.platform !== 'win32' }, () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workdaddy-deadlock-'));
+  // 脚本实际所在位置（模拟非标准安装目录）
+  const runScriptsDir = path.join(dir, 'runScripts');
+  // 目标安装目录的 scripts（与脚本位置不一致 → 触发路径校验 throw）
+  const fakeAppDir = path.join(dir, 'fakeApp');
+  fs.mkdirSync(runScriptsDir, { recursive: true });
+  fs.mkdirSync(fakeAppDir, { recursive: true });
+
+  // 复制脚本与 boundary 到「脚本位置」（apply-update.ps1 用 $PSScriptRoot 加载 boundary）
+  fs.copyFileSync(applyScriptPath, path.join(runScriptsDir, 'apply-update.ps1'));
+  fs.copyFileSync(
+    path.join(scriptsDir, 'windows-process-boundary.ps1'),
+    path.join(runScriptsDir, 'windows-process-boundary.ps1'),
+  );
+
+  // 隔离 APPDATA：pending.json / apply.log 都基于它
+  const appData = path.join(dir, 'AppData', 'Roaming');
+  const localAppData = path.join(dir, 'AppData', 'Local');
+  const updateDir = path.join(appData, 'WorkDaddy', 'update');
+  fs.mkdirSync(updateDir, { recursive: true });
+
+  // 预置 pending.json（模拟 daemon 已退出、apply 启动前的死锁起点）
+  const attemptId = 'test-' + Date.now();
+  fs.writeFileSync(
+    path.join(updateDir, 'pending.json'),
+    JSON.stringify({ at: new Date().toISOString(), attempt: attemptId }),
+  );
+  fs.writeFileSync(
+    path.join(updateDir, 'last-attempt.json'),
+    JSON.stringify({ attemptId, scriptPid: 999999 }),
+  );
+
+  // 运行 apply-update.ps1：AppDir 与脚本位置不一致 → 路径校验 throw
+  // 修复前：throw 在 transcript/finally 之前 → apply.log 不存在 + pending.json 残留
+  // 修复后：throw 在主 try 内 → apply.log 已有 "start" 行 + finally 清 pending.json
+  const result = spawnSync(
+    'powershell',
+    [
+      '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+      '-File', path.join(runScriptsDir, 'apply-update.ps1'),
+      '-SrcPackage', path.join(dir, 'nonexistent.zip'),
+      '-AppDir', fakeAppDir,
+      '-AttemptId', attemptId,
+      '-Port', '47832',
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, APPDATA: appData, LOCALAPPDATA: localAppData, CI: '1' },
+      timeout: 30000,
+      windowsHide: true,
+    },
+  );
+
+  // 预期：非零退出（路径校验 throw → catch → exit 1）
+  assert.ok(result.status !== 0, `expected non-zero exit, got ${result.status}. stderr: ${result.stderr}`);
+
+  // 契约 1：apply.log 必须存在（修复前不存在 → 无从排查 → issue #51 根因）
+  const applyLog = path.join(updateDir, 'apply.log');
+  assert.ok(fs.existsSync(applyLog), 'apply.log must exist after early failure (was missing before fix)');
+  const logContent = fs.readFileSync(applyLog, 'utf8');
+  assert.ok(/start attempt=/.test(logContent), `apply.log must contain start line: ${logContent}`);
+
+  // 契约 2：pending.json 必须被清理（修复前残留 → watchdog 永不拉起 daemon → 死锁）
+  assert.ok(
+    !fs.existsSync(path.join(updateDir, 'pending.json')),
+    'pending.json must be cleaned up after early failure (was leaving deadlock marker before fix)',
+  );
+
+  // 清理
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+});
+
+test('apply-update.ps1: missing-package failure still clears pending.json', { skip: process.platform !== 'win32' }, () => {
+  // 与路径不一致测试互补：路径校验通过（脚本位置 = AppDir/scripts），但包不存在
+  // 验证「停止 watchdog 之前」的中期失败也清 pending（修复前 lifecycleValidated 门控跳过清理）
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'workdaddy-missing-pkg-'));
+  const appDir = path.join(dir, 'app');           // 真实安装目录
+  const runScriptsDir = path.join(appDir, 'scripts'); // 脚本位置 = AppDir/scripts（路径一致）
+  fs.mkdirSync(runScriptsDir, { recursive: true });
+
+  fs.copyFileSync(applyScriptPath, path.join(runScriptsDir, 'apply-update.ps1'));
+  fs.copyFileSync(
+    path.join(scriptsDir, 'windows-process-boundary.ps1'),
+    path.join(runScriptsDir, 'windows-process-boundary.ps1'),
+  );
+
+  const appData = path.join(dir, 'AppData', 'Roaming');
+  const localAppData = path.join(dir, 'AppData', 'Local');
+  const updateDir = path.join(appData, 'WorkDaddy', 'update');
+  fs.mkdirSync(updateDir, { recursive: true });
+
+  const attemptId = 'test-missing-' + Date.now();
+  fs.writeFileSync(path.join(updateDir, 'pending.json'), JSON.stringify({ at: new Date().toISOString(), attempt: attemptId }));
+  fs.writeFileSync(path.join(updateDir, 'last-attempt.json'), JSON.stringify({ attemptId, scriptPid: 999999 }));
+
+  const result = spawnSync(
+    'powershell',
+    [
+      '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+      '-File', path.join(runScriptsDir, 'apply-update.ps1'),
+      '-SrcPackage', path.join(dir, 'definitely-missing.zip'),  // 包不存在 → 路径校验通过后 throw
+      '-AppDir', appDir,  // 路径一致（脚本在 AppDir/scripts）
+      '-AttemptId', attemptId,
+      '-Port', '47832',
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, APPDATA: appData, LOCALAPPDATA: localAppData, CI: '1' },
+      timeout: 30000,
+      windowsHide: true,
+    },
+  );
+
+  assert.ok(result.status !== 0, `expected non-zero exit, got ${result.status}`);
+
+  // apply.log 存在 + pending.json 被清（修复前 lifecycleValidated=false 时 finally 跳过清理）
+  assert.ok(fs.existsSync(path.join(updateDir, 'apply.log')), 'apply.log must exist after missing-package failure');
+  assert.ok(
+    !fs.existsSync(path.join(updateDir, 'pending.json')),
+    'pending.json must be cleared even when failure happens before watchdog stop (lifecycleValidated gate removed)',
+  );
+
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+});


### PR DESCRIPTION
## 根因

`apply-update.ps1` 的早期校验（权限/boundary/路径）位于日志初始化与主 `try/finally` **之前**，失败时静默退出：`apply.log` 不存在、`pending.json` 拋留 → watchdog 检测到标记后**永久拒绝**重启 daemon → 应用卡在「启动较慢」。

触发条件：装在非默认目录（如 D 盘），daemon 认定路径与脚本实际位置不一致，路径校验 throw。

## 改动（2 个源文件 + 1 个测试 + 1 个文档）

### `scripts/apply-update.ps1`
1. **权限探针**保留在目录创建前（`windows-powershell-boundary` 契约要求），但失败时不再 `exit 5`，改为记录 `$privilegeError` 变量，延后到主 try 内 throw（此时 transcript 已启动 → 有日志）。
2. **boundary 加载 + 路径检查**移入主 try：失败会写入 `apply.log` 并由 finally 清理 `pending.json`。
3. **finally 无条件清理** `pending.json`，移除 `$lifecycleValidated` 门控（原门控导致「停止 watchdog 之前」的失败跳过清理）。

### `scripts/watchdog.js`
1. 新增 `schedulePendingRecheck()`：跳过 daemon 重启时启动 15s 复查定时器。
2. 标记被 apply 脚本删除、或宽限期满被 `updatePendingIsActive()` 清理后，**自动重新拉起 daemon**——形成自愈闭环。
3. `shutdown()` 清理定时器，避免泄漏。

原实现：watchdog 检查一次 `pending.json` → 标记存在 → `return`，从此再无人复查。`updatePendingIsActive()` 内置的 10 分钟宽限清理是**死代码**。

## 测试

```bash
node --test test/update-deadlock-recovery.test.js          # 5 个契约测试
node --test test/windows-powershell-boundary.test.js        # 4 个现有契约测试（确认未破坏）
node --test test/windows-privilege-boundary.test.js         # 15 个现有契约测试
```

全部 24/24 通过。其中测试 4 和 5 是 Windows 行为测试，在隔离的临时目录里真实跑 `apply-update.ps1`，精确复现 issue #51 的死锁场景（路径不一致 throw），验证修复后 `apply.log` 已生成 + `pending.json` 已删除。

详见 `docs/issue-51-fix.md`。

Closes #51
