### PR TITLE
feat(growth): 新增「今日活跃」查询接口

### DIFF
--- a/scripts/build-mac-dmg.sh
+++ b/scripts/build-mac-dmg.sh
@@ -42,7 +42,7 @@ chmod 755 "$APP/Contents/MacOS/launcher"
 echo "==> launcher 可执行位已保证: $(stat -f '%Sp' "$APP/Contents/MacOS/launcher")"
 
 # 2) 只覆盖前端代码（保留壳的其余一切：launcher/Info.plist/builtin/node_modules/theme-audit.js）
-for f in daemon.js session-db.js secure-transfer.js windows-process-boundary.js workbuddy-compat.js inject.js theme-patches.js credit-segments.js credit-resource-queries.js credit-request-usage.js credit-usage-store.js atomic-file-write.js ui-port.js checkin-result.js lib.js profiles.js workbuddy-target.js cdp-targets.js sentry-report.js install.sh relaunch-with-cdp.sh uninstall.sh apply-update.sh; do
+for f in daemon.js session-db.js secure-transfer.js windows-process-boundary.js workbuddy-compat.js inject.js theme-patches.js credit-segments.js credit-resource-queries.js credit-request-usage.js credit-usage-store.js atomic-file-write.js ui-port.js checkin-result.js growth-active.js lib.js profiles.js workbuddy-target.js cdp-targets.js sentry-report.js install.sh relaunch-with-cdp.sh uninstall.sh apply-update.sh; do
   [ -f "scripts/$f" ] && cp "scripts/$f" "$APP/Contents/Resources/scripts/$f"
 done
 WALLPAPER_OVERRIDE="scripts/builtin-overrides/wallpaper-06.webp"
@@ -68,6 +68,7 @@ chmod 644 "$APP/Contents/Resources/scripts/session-db.js" \
   "$APP/Contents/Resources/scripts/atomic-file-write.js" \
   "$APP/Contents/Resources/scripts/ui-port.js" \
   "$APP/Contents/Resources/scripts/checkin-result.js" \
+  "$APP/Contents/Resources/scripts/growth-active.js" \
   "$APP/Contents/Resources/scripts/workbuddy-compat.js" \
   "$APP/Contents/Resources/scripts/inject.js" \
   "$APP/Contents/Resources/scripts/theme-patches.js"

--- a/scripts/daemon.js
+++ b/scripts/daemon.js
@@ -104,6 +104,7 @@ const { buildCreditResourceBody } = require('./credit-resource-queries.js');
 const { fetchUsageSinceAnchor, startOfLocalDay } = require('./credit-request-usage.js');
 const { createCreditUsageStore } = require('./credit-usage-store.js');
 const { classifyCheckinResult } = require('./checkin-result.js');
+const { fetchGrowthTodayActive } = require('./growth-active.js');
 const {
   captureException,
   captureMessage,
@@ -230,8 +231,9 @@ const DATA_DIR = defaultDataDir();
 // 1.1.25：内置官方壁纸更新时刷新数据目录旧副本；新 profile 默认启用 WorkDaddy 壁纸主题。
 // 1.1.26：daemon 启动 30 秒后补签，并将全账号签到兜底周期缩短为 1 小时。
 // 1.1.27：修复 Windows 原生启动路径发现、旧托管 Node 升级和首次会话播种失败；补充脱敏启动诊断与匿名安装 ID。
-const DAEMON_VERSION = '1.1.27';
-const DAEMON_BUILD_ID = 'release-1.1.27-20260831-windows-sentry-diagnostics';
+// 1.1.28：新增「今日活跃」查询接口（成长中心热力墙 is_active），复用签到 Bearer 鉴权与 profile 归属域名。
+const DAEMON_VERSION = '1.1.28';
+const DAEMON_BUILD_ID = 'release-1.1.28-20260901-windows-growth-active';
 const HOST = '127.0.0.1';
 const IS_WIN = process.platform === 'win32'; // Windows 移植：平台分支开关（macOS 行为保持不变）
 // Windows 安装目录（install.ps1 铺、launcher 用、更新替换目标），对应 macOS 的 /Applications/WorkDaddy.app
@@ -5780,6 +5782,26 @@ function handleApi(req, res) {
         return json(res, 200, payload);
       } catch (e) {
         log(`[credits] 查询 ${uid} 积分失败: ${e.message}`);
+        return json(res, 500, { ok: false, error: e.message });
+      }
+    });
+  }
+
+  // 查询指定账号今日是否活跃（成长中心热力墙 is_active）
+  if (req.method === 'POST' && p === '/api/growth/today-active') {
+    return readBody(req).then(async (body) => {
+      const uid = (body.uid || '').trim();
+      if (!uid) return json(res, 400, { ok: false, error: '缺少 uid' });
+      try {
+        const file = path.join(DATA_DIR, 'accounts', `${uid}.info`);
+        if (!fs.existsSync(file)) return json(res, 404, { ok: false, error: '账号备份不存在' });
+        const j = JSON.parse(fs.readFileSync(file, 'utf8'));
+        const tk = j.auth && j.auth.accessToken;
+        if (!tk) return json(res, 400, { ok: false, error: '备份中无 accessToken' });
+        const today = await fetchGrowthTodayActive(tk, { apiHost: PROFILE.apiHost });
+        return json(res, 200, { ok: true, uid, ...today });
+      } catch (e) {
+        log(`[growth] 查询 ${uid} 今日活跃失败: ${e.message}`);
         return json(res, 500, { ok: false, error: e.message });
       }
     });

--- a/scripts/growth-active.js
+++ b/scripts/growth-active.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const GROWTH_ACTIVE_TIMEOUT_MS = 12000;
+
+/**
+ * 查询指定账号今日是否活跃（WorkBuddy 成长中心活跃地图）。
+ * 复用签到/积分的 Bearer 鉴权与 profile 归属域名（国内 www.workbuddy.cn / 国际 www.workbuddy.ai）。
+ * 返回 { is_active, date, score, status_text }；失败抛 Error。
+ */
+async function fetchGrowthTodayActive(accessToken, options = {}) {
+  const apiHost = String(options.apiHost || 'https://www.workbuddy.cn').replace(/\/+$/, '');
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+    ? options.timeoutMs
+    : GROWTH_ACTIVE_TIMEOUT_MS;
+  if (!accessToken || typeof fetchImpl !== 'function') {
+    throw new Error('成长活跃查询参数不完整');
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(`${apiHost}/activity/growth/heatmap`, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json, text/plain, */*',
+        'x-client-platform': 'web',
+        origin: apiHost,
+        referer: `${apiHost}/profile/growth-center`,
+        authorization: `Bearer ${accessToken}`,
+      },
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload;
+    try {
+      payload = JSON.parse(text);
+    } catch (_) {
+      throw new Error('成长活跃接口返回了无法解析的数据');
+    }
+    if (!response.ok) throw new Error(`成长活跃接口 HTTP ${response.status}`);
+    if (payload.code !== 0 && payload.code !== undefined && payload.code !== null) {
+      throw new Error(payload.msg || `成长活跃接口 code=${payload.code}`);
+    }
+    const today = payload.data && typeof payload.data === 'object' ? payload.data.today : null;
+    if (!today || typeof today !== 'object') throw new Error('成长活跃接口缺少 data.today');
+    return {
+      is_active: today.is_active === true,
+      date: typeof today.date === 'string' ? today.date : null,
+      score: Number.isFinite(Number(today.score)) ? Number(today.score) : null,
+      status_text: typeof today.status_text === 'string' ? today.status_text : '',
+    };
+  } catch (error) {
+    if (error && error.name === 'AbortError') throw new Error('成长活跃接口请求超时');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+module.exports = { fetchGrowthTodayActive };

--- a/test/growth-active.test.js
+++ b/test/growth-active.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { fetchGrowthTodayActive } = require('../scripts/growth-active.js');
+
+function mockFetch(payload, { ok = true, status = 200 } = {}) {
+  const text = typeof payload === 'string' ? payload : JSON.stringify(payload);
+  return async () => ({ ok, status, text: async () => text });
+}
+
+test('返回今日活跃 true 与今日字段', async () => {
+  const today = { date: '2026-09-01', score: 106, is_active: true, status_text: '今日已活跃' };
+  const r = await fetchGrowthTodayActive('tok', {
+    fetchImpl: mockFetch({ code: 0, msg: 'OK', data: { today } }),
+  });
+  assert.deepEqual(r, { is_active: true, date: '2026-09-01', score: 106, status_text: '今日已活跃' });
+});
+
+test('is_active=false 返回 false，缺省字段归 null/空', async () => {
+  const r = await fetchGrowthTodayActive('tok', {
+    fetchImpl: mockFetch({ code: 0, data: { today: { date: '2026-09-01', is_active: false } } }),
+  });
+  assert.equal(r.is_active, false);
+  assert.equal(r.score, null);
+  assert.equal(r.status_text, '');
+});
+
+test('code 非 0 抛错', async () => {
+  await assert.rejects(
+    fetchGrowthTodayActive('tok', { fetchImpl: mockFetch({ code: 401, msg: '未授权' }) }),
+    /未授权/
+  );
+});
+
+test('HTTP 非 ok 抛错', async () => {
+  await assert.rejects(
+    fetchGrowthTodayActive('tok', { fetchImpl: mockFetch('{}', { ok: false, status: 500 }) }),
+    /HTTP 500/
+  );
+});
+
+test('无法解析的 JSON 抛错', async () => {
+  await assert.rejects(
+    fetchGrowthTodayActive('tok', { fetchImpl: mockFetch('not-json') }),
+    /无法解析/
+  );
+});
+
+test('缺 data.today 抛错', async () => {
+  await assert.rejects(
+    fetchGrowthTodayActive('tok', { fetchImpl: mockFetch({ code: 0, data: {} }) }),
+    /缺少 data\.today/
+  );
+});
+
+test('缺 accessToken 抛错', async () => {
+  await assert.rejects(
+    fetchGrowthTodayActive('', { fetchImpl: mockFetch({ code: 0 }) }),
+    /参数不完整/
+  );
+});


### PR DESCRIPTION
新增成长中心活跃地图接口的「今日活跃」查询能力：

- scripts/growth-active.js：fetchGrowthTodayActive 调 /activity/growth/heatmap， 解析 data.today 返回 {is_active, date, score, status_text}
- daemon 新增 POST /api/growth/today-active，按 uid 读账号 accessToken 查询
- 复用签到 Bearer 鉴权与 PROFILE.apiHost 归属域名
- 递增 DAEMON_VERSION 至 1.1.28
- build-mac-dmg.sh 打包清单补充 growth-active.js
- 新增 test/growth-active.test.js（7 用例）