### PR TITLE
修复 macOS 启动弹「安装 Rosetta」：声明 arm64 架构优先级 + 更新后刷新 LaunchServices 注册

### DIFF
--- a/scripts/apply-update.sh
+++ b/scripts/apply-update.sh
@@ -109,6 +109,24 @@ mkdir -p "$(dirname "$APP_PATH")"
 cp -R "$SRC_APP" "$APP_PATH" || rollback 22
 chmod -R u+rwX "$APP_PATH" || rollback 23
 xattr -cr "$APP_PATH" 2>&1 || log "清除隔离属性失败（继续，可能已无隔离属性）"
+
+# 覆盖 bundle 之后必须让 LaunchServices 重新注册。壳的 CFBundleExecutable 是 bash 脚本、
+# bundle 也未签名，旧注册里可能带着 macOS 伪造的 LSArchitecturePriority=(x86_64, arm64)
+# 缓存；只替换文件不会刷新该缓存，下一次启动仍按 Rosetta 拉起并弹「需要安装 Rosetta」。
+# 必须先注销再注册才会真正重读 Info.plist 的 arm64 声明，并顺带清掉已挂载 dmg 卷里
+# 同名副本的旧注册（用户可能曾直接从 dmg 双击启动过）。
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+if [ -x "$LSREGISTER" ]; then
+  for stale in /Volumes/*/WorkDaddy*.app; do
+    [ -d "$stale" ] || continue
+    "$LSREGISTER" -u "$stale" >/dev/null 2>&1 || log "注销挂载卷残留注册失败: $stale"
+  done
+  "$LSREGISTER" -u "$APP_PATH" >/dev/null 2>&1 || log "注销旧注册失败（继续）"
+  "$LSREGISTER" -f "$APP_PATH" >/dev/null 2>&1 || log "重新注册失败（继续）"
+  log "LaunchServices 注册已刷新: $APP_PATH"
+else
+  log "未找到 lsregister，跳过注册刷新"
+fi
 TARGET_DAEMON_VERSION="$(grep -o "const DAEMON_VERSION = '[^']*'" "$APP_PATH/Contents/Resources/scripts/daemon.js" | head -1 || true)"
 log "target daemon version=$TARGET_DAEMON_VERSION"
 

--- a/scripts/build-mac-dmg.sh
+++ b/scripts/build-mac-dmg.sh
@@ -124,6 +124,22 @@ if /usr/libexec/PlistBuddy -c 'Print :CFBundleIconName' "$PACKAGE_APP/Contents/I
 else
   /usr/libexec/PlistBuddy -c 'Add :CFBundleIconName string AppIcon' "$PACKAGE_APP/Contents/Info.plist"
 fi
+# 壳的 CFBundleExecutable 是 bash 脚本而不是 Mach-O，LaunchServices 判定不了架构时会
+# 自行伪造 LSArchitecturePriority=(x86_64, arm64)，Apple Silicon 上就优先走 Rosetta 启动；
+# 未安装 Rosetta 的机器每次双击都弹「需要安装 Rosetta」的安装窗。产物显式声明 arm64
+# 优先即可原生启动，dmg 卷内的副本（用户直接从 dmg 双击的场景）同样生效。
+LS_ARCH_PRIORITY="arm64"
+if /usr/libexec/PlistBuddy -c 'Print :LSArchitecturePriority' "$PACKAGE_APP/Contents/Info.plist" >/dev/null 2>&1; then
+  /usr/libexec/PlistBuddy -c 'Delete :LSArchitecturePriority' "$PACKAGE_APP/Contents/Info.plist"
+fi
+/usr/libexec/PlistBuddy -c 'Add :LSArchitecturePriority array' "$PACKAGE_APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Add :LSArchitecturePriority:0 string ${LS_ARCH_PRIORITY}" "$PACKAGE_APP/Contents/Info.plist"
+BUILT_ARCH_PRIORITY="$(/usr/libexec/PlistBuddy -c 'Print :LSArchitecturePriority:0' "$PACKAGE_APP/Contents/Info.plist" 2>/dev/null || true)"
+if [ "$BUILT_ARCH_PRIORITY" != "$LS_ARCH_PRIORITY" ]; then
+  echo "错误：产物 Info.plist 未声明 ${LS_ARCH_PRIORITY} 架构优先级（实际: ${BUILT_ARCH_PRIORITY:-空}）" >&2
+  exit 3
+fi
+echo "==> 架构优先级已声明: ${BUILT_ARCH_PRIORITY}（避免 Rosetta 安装窗）"
 sed -i.bak "s|^PROFILE=.*|PROFILE=\"${PROFILE}\"|" "$PACKAGE_APP/Contents/MacOS/launcher"
 rm -f "$PACKAGE_APP/Contents/MacOS/launcher.bak"
 # 企业版可能在 /Applications 下使用不同的 .app 名称。把官方路径优先、

--- a/test/macos-launch-services.test.js
+++ b/test/macos-launch-services.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..');
+const read = (name) => fs.readFileSync(path.join(repoRoot, 'scripts', name), 'utf8');
+
+const LSREGISTER_PATH =
+  '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister';
+
+test('macOS DMG declares an arm64 LaunchServices architecture priority', () => {
+  const build = read('build-mac-dmg.sh');
+  assert.match(build, /LS_ARCH_PRIORITY="arm64"/);
+  assert.match(build, /Add :LSArchitecturePriority array/);
+  assert.match(build, /Add :LSArchitecturePriority:0 string \$\{LS_ARCH_PRIORITY\}/);
+  // 声明必须落在打包产物上，而不是只在仓库里的壳上。
+  assert.match(build, /Print :LSArchitecturePriority:0' "\$PACKAGE_APP\/Contents\/Info\.plist"/);
+});
+
+test('macOS DMG build fails loudly when the arch priority is not written', () => {
+  const build = read('build-mac-dmg.sh');
+  const verify = build.indexOf('BUILT_ARCH_PRIORITY=');
+  assert.notEqual(verify, -1);
+  const guard = build.slice(verify, build.indexOf('echo "==> 架构优先级已声明'));
+  assert.match(guard, /if \[ "\$BUILT_ARCH_PRIORITY" != "\$LS_ARCH_PRIORITY" \]; then/);
+  assert.match(guard, /exit 3/);
+});
+
+test('macOS updater refreshes the LaunchServices registration before relaunching', () => {
+  const script = read('apply-update.sh');
+  assert.match(script, new RegExp(LSREGISTER_PATH.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  assert.match(script, /"\$LSREGISTER" -u "\$APP_PATH"/);
+  assert.match(script, /"\$LSREGISTER" -f "\$APP_PATH"/);
+  assert.match(script, /\/Volumes\/\*\/WorkDaddy\*\.app/);
+
+  const xattr = script.indexOf('xattr -cr "$APP_PATH"');
+  const refresh = script.indexOf('"$LSREGISTER" -u "$APP_PATH"');
+  const relaunch = script.indexOf('open -n "$APP_PATH" || rollback 27');
+  assert.notEqual(xattr, -1);
+  assert.notEqual(refresh, -1);
+  assert.notEqual(relaunch, -1);
+  assert.ok(xattr < refresh, 'registration refresh must follow the bundle replacement');
+  assert.ok(refresh < relaunch, 'registration refresh must happen before the relaunch');
+});
+
+test('macOS updater never fails the update because of registration cleanup', () => {
+  const script = read('apply-update.sh');
+  assert.match(script, /"\$LSREGISTER" -u "\$APP_PATH" >\/dev\/null 2>&1 \|\| log /);
+  assert.match(script, /"\$LSREGISTER" -f "\$APP_PATH" >\/dev\/null 2>&1 \|\| log /);
+  assert.match(script, /未找到 lsregister，跳过注册刷新/);
+});


### PR DESCRIPTION
壳的 CFBundleExecutable 是 bash 脚本、bundle 也未签名，LaunchServices 判定不了架构时会自行 伪造 LSArchitecturePriority=(x86_64, arm64)，Apple Silicon 上于是优先走 Rosetta 启动；没装 Rosetta 的机器每次双击都弹「需要安装 Rosetta」的安装窗（macOS 26.6 实测对未签名脚本型 app 一律如此，ad-hoc 签名无法解决，只有 Info.plist 显式声明生效）。

- build-mac-dmg.sh：打包时在产物 Info.plist 写入 LSArchitecturePriority=(arm64)（已有旧键先 Delete 再 Add），随后读回校验，不一致直接 exit 3 失败。产物与 dmg 卷内副本一并生效，用户从 挂载的 dmg 直接双击也不再触发 Rosetta。
- apply-update.sh：覆盖 bundle 后先注销再重新注册 LaunchServices。只替换文件不会刷新带伪造 架构优先级缓存的旧注册（实测 lsregister -f 不重读 Info.plist，必须 -u 后再 -f），否则更新 后首次启动仍会弹窗；同时清掉 /Volumes/*/WorkDaddy*.app 的残留注册。这些步骤失败只记日志， 不阻断更新流程。
- 新增 test/macos-launch-services.test.js：覆盖架构声明、构建期校验、注册刷新顺序（必须排在 重新派发应用之前）与「注册清理不得导致更新失败」。

验证：bash -n 两个脚本通过；新测试 4/4 通过；全量 node --test test/*.test.js 为 612 pass / 2 fail / 8 skip，两个失败均为既有问题（examples/*.json 被 CRLF 改写导致 sha256 不符、 automation.test.js 缺 automationDeepLocatorExpression 符号），与本改动无关。 未验证：DMG 产物与真实双击启动——本机缺 WorkDaddy.app 壳（.gitignore 排除），无法运行 build-mac-dmg.sh 做端到端打包。