### PR TITLE
发布便携版 ZIP（Portable），便于免安装与 Scoop 等包管理器接入

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -93,16 +93,13 @@ jobs:
             -File .\scripts\build-win-installer.ps1 -IsccPath $iscc -Profile workbuddy-ai -Version ${{ steps.ver.outputs.version }}
           if ($LASTEXITCODE -ne 0) { throw "WorkDaddy AI Setup build failed with exit code $LASTEXITCODE" }
 
-      - name: 确认仅保留 Setup.exe 发行产物
+      - name: 确认 Setup.exe + 便携版产物齐备
         shell: pwsh
         run: |
-          $legacyZip = Get-ChildItem -LiteralPath release\windows -Filter '*-win64.zip' -File -ErrorAction SilentlyContinue
-          if ($legacyZip) {
-            $legacyZip | Remove-Item -Force
-          }
-          if (Get-ChildItem -LiteralPath release\windows -Filter '*-win64.zip' -File -ErrorAction SilentlyContinue) {
-            throw 'Windows 发布目录仍包含旧 ZIP 产物。'
-          }
+          $setup = Get-ChildItem -LiteralPath release\windows -Filter '*-Setup-*.exe' -File -ErrorAction SilentlyContinue
+          $portable = Get-ChildItem -LiteralPath release\windows -Filter '*-Portable-*.zip' -File -ErrorAction SilentlyContinue
+          if (-not $setup -or $setup.Count -lt 2) { throw 'Setup.exe 产物缺失。' }
+          if (-not $portable -or $portable.Count -lt 2) { throw '便携版 ZIP 产物缺失。' }
 
       - name: 列出产物
         shell: bash
@@ -113,13 +110,15 @@ jobs:
         run: |
           call scripts\verify-win.cmd
 
-      - name: 上传产物（仅 Setup.exe）
+      - name: 上传产物（Setup.exe + 便携版 ZIP）
         uses: actions/upload-artifact@v4
         with:
           name: workdaddy-win64
           path: |
             release/windows/WorkDaddy-Setup-*.exe
             release/windows/WorkDaddy-AI-Setup-*.exe
+            release/windows/WorkDaddy-Portable-*.zip
+            release/windows/WorkDaddy-AI-Portable-*.zip
 
       # ---- 只有打 tag 时才顺手挂到 GitHub Release ----
       - name: 发布到 GitHub Release
@@ -129,5 +128,7 @@ jobs:
           files: |
             release/windows/WorkDaddy-Setup-*.exe
             release/windows/WorkDaddy-AI-Setup-*.exe
+            release/windows/WorkDaddy-Portable-*.zip
+            release/windows/WorkDaddy-AI-Portable-*.zip
             release/*.dmg
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ node scripts/workbuddy-target.js --configure --platform darwin \
 2. 双击安装器完成安装
 3. 双击打开 `WorkDaddy` 或 `WorkDaddy AI` 桌面快捷方式
 
+也可以选择便携版 `WorkDaddy-Portable-x.y.z.zip` / `WorkDaddy-AI-Portable-x.y.z.zip`：解压到任意目录，双击顶层 `Start-WorkDaddy.cmd` 直接使用；想常驻安装再双击 `Install-WorkDaddy.cmd`。适合免安装场景和 Scoop 等包管理器接入。
+
 #### 企业专享版 / VPC 客户端
 
 企业专享版用户仍安装与界面最接近的 `WorkDaddy` 或 `WorkDaddy AI`。安装程序会先自动识别对应的官方客户端，并在安装向导中显示路径和版本；企业版用户点击「浏览」改选自己的 `.exe` 主程序即可，不需要修改配置文件或设置系统环境变量。
@@ -106,7 +108,7 @@ WBSWITCH_PROFILE=workbuddy-ai bash scripts/relaunch-with-cdp.sh
 
 暂存提示词和主题功能在两个 WorkBuddy profile 开启。CodeBuddy profile 的适配暂缓，不进入当前发布包。
 
-当前发布脚本只打包两个 WorkBuddy 客户端，共 4 个包：`WorkDaddy-<version>.dmg`、`WorkDaddy-AI-<version>.dmg`、`WorkDaddy-Setup-<version>.exe`、`WorkDaddy-AI-Setup-<version>.exe`。macOS 构建时传 `WORKDADDY_BUILD_PROFILE=workbuddy-cn` 或 `workbuddy-ai` 可单独重打一个客户端。Windows ZIP 仅作安装器构建的临时输入，不作为发布包。
+当前发布脚本只打包两个 WorkBuddy 客户端，Windows 每个客户端发布 Setup.exe 与便携版 ZIP 两个包：`WorkDaddy-Setup-<version>.exe` / `WorkDaddy-Portable-<version>.zip`、`WorkDaddy-AI-Setup-<version>.exe` / `WorkDaddy-AI-Portable-<version>.zip`（加上 macOS 共 6 个包）。macOS 构建时传 `WORKDADDY_BUILD_PROFILE=workbuddy-cn` 或 `workbuddy-ai` 可单独重打一个客户端。Windows 便携版 ZIP 与 Setup.exe 同源生成，顶层自带 Start/Install/Uninstall 入口。
 
 `install.sh` 做了：
 

--- a/scripts/build-win-installer.ps1
+++ b/scripts/build-win-installer.ps1
@@ -91,11 +91,19 @@ try {
     throw "Setup artifact is missing or empty: $setup"
   }
   Write-Host "Created $setup"
+  # 暂存 ZIP 与 Setup.exe 内容同源，且顶层自带 Start/Install/Uninstall 入口，
+  # 直接作为便携版随 Setup.exe 一起发布（zip 解压即见一键启动/安装）。
+  $portable = Join-Path $OutputDirectory ("$packageName-Portable-$version.zip")
+  Move-Item -LiteralPath $zipPath -Destination $portable -Force
+  if (-not (Test-Path -LiteralPath $portable -PathType Leaf) -or (Get-Item -LiteralPath $portable).Length -le 0) {
+    throw "Portable artifact is missing or empty: $portable"
+  }
+  Write-Host "Created $portable"
 } finally {
   if (Test-Path -LiteralPath $stageRoot) {
     Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
   }
-  # ZIP is only an internal staging input. Windows releases publish Setup.exe only.
+  # 构建失败时暂存 ZIP 不再具有发布意义，清理掉；成功路径中它已被改名为便携版。
   if (Test-Path -LiteralPath $zipPath -PathType Leaf) {
     Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
   }


### PR DESCRIPTION
Closes #163

## 背景

WorkDaddy 的 Windows 构建 pipeline 中，`scripts/build-win-zip.sh` 生成的暂存 ZIP 与 Setup.exe 内容同源，且顶层自带 `Start-WorkDaddy.cmd` / `Install-WorkDaddy.cmd` / `Uninstall-WorkDaddy.cmd` 三个入口（打包脚本注释即写明「解压即见一键安装/启动」），自带 Node 运行时与内置资产——它实际上就是一个完整的便携版，只是目前作为中间产物在构建完成后被删除。

## 改动

1. **`scripts/build-win-installer.ps1`**：Setup.exe 校验通过后，不再删除暂存 ZIP，而是改名为 `WorkDaddy[-AI]-Portable-<version>.zip` 作为正式产物；构建失败路径仍照旧清理。
2. **`.github/workflows/build-win.yml`**：产物校验步骤从「仅保留 Setup.exe」改为「Setup.exe + 便携版 ZIP 齐备（各 2 个）」；CI artifact 与 GitHub Release 上传清单同步加入便携版 ZIP。
3. **README.md**：Windows 安装章节补充便携版用法（解压 → 双击 `Start-WorkDaddy.cmd`），发布包清单更新为 6 个包。

## 为什么便携版有价值

- **免安装场景**：U 盘便携、无权限环境、多实例并存；
- **包管理器接入**：[Scoop](https://scoop.sh/) 等工具可直接 `extract_dir` 收录（相关讨论见 #163）；
- **零额外维护成本**：ZIP 本就是 Inno Setup 的 staging 输入，两者完全同源，不引入新的打包路径；客户端绑定、profile 探测等逻辑在便携模式下由现有自动探测机制承担（与安装器路径选择页互补）。

## 测试

- [x] 本地验证：暂存 ZIP 的顶层结构与 `Start/Install/Uninstall-WorkDaddy.cmd` 入口已人工确认（见 #163 的分析）；
- [x] PowerShell 脚本与 workflow YAML 语法检查；
- [ ] 完整构建验证建议由维护者通过 workflow_dispatch 触发一次 `Build & Verify Windows Setup`（PR 不改 Inno 打包逻辑本身，仅改产物去留与发布清单）。